### PR TITLE
FT-12: Add Encyclopedia views and templates with navigation

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -62,7 +62,7 @@ ROOT_URLCONF = 'config.urls'
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [],
+        'DIRS': [BASE_DIR / 'templates'],
         'APP_DIRS': True,
         'OPTIONS': {
             'context_processors': [

--- a/config/urls.py
+++ b/config/urls.py
@@ -15,12 +15,13 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.contrib import admin
-from django.urls import path
+from django.urls import path, include
 from django.conf import settings
 from django.conf.urls.static import static
 
 urlpatterns = [
     path('admin/', admin.site.urls),
+    path('', include('content.urls')),
 ]
 
 # Serve media files in development

--- a/content/urls.py
+++ b/content/urls.py
@@ -1,0 +1,9 @@
+from django.urls import path
+from . import views
+
+app_name = 'content'
+
+urlpatterns = [
+    path('encyclopedia/', views.EncyclopediaListView.as_view(), name='encyclopedia_list'),
+    path('encyclopedia/<slug:slug>/', views.EncyclopediaDetailView.as_view(), name='encyclopedia_detail'),
+]

--- a/content/views.py
+++ b/content/views.py
@@ -1,3 +1,49 @@
 from django.shortcuts import render
+from django.views.generic import ListView, DetailView
+from content.models import Encyclopedia
 
-# Create your views here.
+
+class EncyclopediaListView(ListView):
+    """
+    List view for encyclopedia entries.
+    Shows all top-level entries (parent=None) with pagination.
+    """
+    model = Encyclopedia
+    template_name = 'encyclopedia/list.html'
+    context_object_name = 'entries'
+    paginate_by = 50
+
+    def get_queryset(self):
+        """Filter to show only top-level entries ordered by name."""
+        return Encyclopedia.objects.filter(parent=None).order_by('name')
+
+
+class EncyclopediaDetailView(DetailView):
+    """
+    Detail view for a single encyclopedia entry.
+    Displays full entry details including hierarchy, images, and tags.
+    """
+    model = Encyclopedia
+    template_name = 'encyclopedia/detail.html'
+    context_object_name = 'entry'
+    slug_field = 'slug'
+    slug_url_kwarg = 'slug'
+
+    def get_context_data(self, **kwargs):
+        """Add additional context for ancestors, children, and related content."""
+        context = super().get_context_data(**kwargs)
+        entry = self.object
+
+        # Add breadcrumb navigation
+        context['ancestors'] = entry.get_ancestors()
+
+        # Add child entries
+        context['children'] = entry.children.all().order_by('name')
+
+        # Add images
+        context['images'] = entry.images.all()
+
+        # Add tags
+        context['tags'] = entry.encyclopedia_tags.all()
+
+        return context

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% block title %}Food Table{% endblock %}</title>
+    <!-- Bootstrap CSS -->
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    {% block extra_css %}{% endblock %}
+</head>
+<body>
+    <!-- Header Navigation -->
+    <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+        <div class="container">
+            <a class="navbar-brand" href="/">Food Table</a>
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+                <span class="navbar-toggler-icon"></span>
+            </button>
+            <div class="collapse navbar-collapse" id="navbarNav">
+                <ul class="navbar-nav">
+                    <li class="nav-item">
+                        <a class="nav-link" href="{% url 'content:encyclopedia_list' %}">Encyclopedia</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link" href="#">Reviews</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link" href="#">Recipes</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link" href="#">Search</a>
+                    </li>
+                </ul>
+            </div>
+        </div>
+    </nav>
+
+    <!-- Main Content -->
+    <main class="container my-4">
+        {% block content %}
+        {% endblock %}
+    </main>
+
+    <!-- Footer -->
+    <footer class="bg-light text-center py-3 mt-5">
+        <div class="container">
+            <p class="text-muted mb-0">&copy; 2024 Food Table. All rights reserved.</p>
+        </div>
+    </footer>
+
+    <!-- Bootstrap JS -->
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+    {% block extra_js %}{% endblock %}
+</body>
+</html>

--- a/templates/encyclopedia/detail.html
+++ b/templates/encyclopedia/detail.html
@@ -1,0 +1,173 @@
+{% extends 'base.html' %}
+
+{% block title %}{{ entry.name }} - Encyclopedia - Food Table{% endblock %}
+
+{% block content %}
+<!-- Breadcrumb Navigation -->
+<nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a href="{% url 'content:encyclopedia_list' %}">Encyclopedia</a></li>
+        {% for ancestor in ancestors reversed %}
+        <li class="breadcrumb-item">
+            <a href="{% url 'content:encyclopedia_detail' ancestor.slug %}">{{ ancestor.name }}</a>
+        </li>
+        {% endfor %}
+        <li class="breadcrumb-item active" aria-current="page">{{ entry.name }}</li>
+    </ol>
+</nav>
+
+<!-- Entry Header -->
+<div class="row">
+    <div class="col-12">
+        <h1 class="mb-3">{{ entry.name }}</h1>
+        <div class="mb-3">
+            {% if entry.cuisine_type %}
+            <span class="badge bg-secondary">{{ entry.cuisine_type }}</span>
+            {% endif %}
+            {% if entry.dish_category %}
+            <span class="badge bg-info">{{ entry.dish_category }}</span>
+            {% endif %}
+            {% if entry.region %}
+            <span class="badge bg-success">{{ entry.region }}</span>
+            {% endif %}
+        </div>
+    </div>
+</div>
+
+<!-- Images Gallery -->
+{% if images %}
+<div class="row mb-4">
+    <div class="col-12">
+        <h3>Images</h3>
+        <div class="row row-cols-2 row-cols-md-3 row-cols-lg-4 g-3">
+            {% for image in images %}
+            <div class="col">
+                <img src="{{ image.image.url }}" class="img-fluid rounded" alt="{{ image.caption }}" style="width: 100%; height: 200px; object-fit: cover;">
+                {% if image.caption %}
+                <p class="small text-muted mt-1">{{ image.caption }}</p>
+                {% endif %}
+            </div>
+            {% endfor %}
+        </div>
+    </div>
+</div>
+{% endif %}
+
+<!-- Main Content -->
+<div class="row">
+    <div class="col-lg-8">
+        <div class="card mb-4">
+            <div class="card-body">
+                <h3 class="card-title">Description</h3>
+                <p class="card-text">{{ entry.description }}</p>
+            </div>
+        </div>
+
+        {% if entry.history %}
+        <div class="card mb-4">
+            <div class="card-body">
+                <h3 class="card-title">History</h3>
+                <p class="card-text">{{ entry.history }}</p>
+            </div>
+        </div>
+        {% endif %}
+
+        {% if entry.cultural_significance %}
+        <div class="card mb-4">
+            <div class="card-body">
+                <h3 class="card-title">Cultural Significance</h3>
+                <p class="card-text">{{ entry.cultural_significance }}</p>
+            </div>
+        </div>
+        {% endif %}
+
+        {% if entry.popular_examples %}
+        <div class="card mb-4">
+            <div class="card-body">
+                <h3 class="card-title">Popular Examples</h3>
+                <p class="card-text">{{ entry.popular_examples }}</p>
+            </div>
+        </div>
+        {% endif %}
+    </div>
+
+    <!-- Sidebar -->
+    <div class="col-lg-4">
+        <!-- Tags -->
+        {% if tags %}
+        <div class="card mb-4">
+            <div class="card-body">
+                <h5 class="card-title">Tags</h5>
+                <div>
+                    {% for tag_obj in tags %}
+                    <span class="badge bg-primary me-1 mb-1">{{ tag_obj.tag }}</span>
+                    {% endfor %}
+                </div>
+            </div>
+        </div>
+        {% endif %}
+
+        <!-- Child Entries -->
+        {% if children %}
+        <div class="card mb-4">
+            <div class="card-body">
+                <h5 class="card-title">Sub-categories</h5>
+                <ul class="list-group list-group-flush">
+                    {% for child in children %}
+                    <li class="list-group-item">
+                        <a href="{% url 'content:encyclopedia_detail' child.slug %}">{{ child.name }}</a>
+                    </li>
+                    {% endfor %}
+                </ul>
+            </div>
+        </div>
+        {% endif %}
+
+        <!-- Metadata -->
+        <div class="card mb-4">
+            <div class="card-body">
+                <h5 class="card-title">Information</h5>
+                <p class="card-text small">
+                    <strong>Created:</strong> {{ entry.created_at|date:"M d, Y" }}<br>
+                    <strong>Updated:</strong> {{ entry.updated_at|date:"M d, Y" }}<br>
+                    {% if entry.created_by %}
+                    <strong>Author:</strong> {{ entry.created_by.username }}<br>
+                    {% endif %}
+                    <strong>Version:</strong> {{ entry.version }}
+                </p>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- Related Reviews (Placeholder) -->
+<div class="row mt-4">
+    <div class="col-12">
+        <div class="card">
+            <div class="card-body">
+                <h4 class="card-title">Related Reviews</h4>
+                <p class="text-muted">Reviews feature coming soon...</p>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- Related Recipes (Placeholder) -->
+<div class="row mt-4">
+    <div class="col-12">
+        <div class="card">
+            <div class="card-body">
+                <h4 class="card-title">Related Recipes</h4>
+                <p class="text-muted">Recipes feature coming soon...</p>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- Back Button -->
+<div class="row mt-4">
+    <div class="col-12">
+        <a href="{% url 'content:encyclopedia_list' %}" class="btn btn-secondary">Back to Encyclopedia</a>
+    </div>
+</div>
+{% endblock %}

--- a/templates/encyclopedia/list.html
+++ b/templates/encyclopedia/list.html
@@ -1,0 +1,103 @@
+{% extends 'base.html' %}
+
+{% block title %}Encyclopedia - Food Table{% endblock %}
+
+{% block content %}
+<div class="row">
+    <div class="col-12">
+        <h1 class="mb-4">Encyclopedia</h1>
+        <p class="lead">Browse our collection of food knowledge entries</p>
+    </div>
+</div>
+
+<!-- Entries Grid -->
+<div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-4">
+    {% for entry in entries %}
+    <div class="col">
+        <div class="card h-100">
+            {% if entry.images.all.0 %}
+            <img src="{{ entry.images.all.0.image.url }}" class="card-img-top" alt="{{ entry.name }}" style="height: 200px; object-fit: cover;">
+            {% else %}
+            <div class="card-img-top bg-light d-flex align-items-center justify-content-center" style="height: 200px;">
+                <span class="text-muted">No image</span>
+            </div>
+            {% endif %}
+            <div class="card-body">
+                <h5 class="card-title">{{ entry.name }}</h5>
+                <p class="card-text">
+                    {{ entry.description|truncatewords:20 }}
+                </p>
+                {% if entry.cuisine_type %}
+                <span class="badge bg-secondary">{{ entry.cuisine_type }}</span>
+                {% endif %}
+                {% if entry.dish_category %}
+                <span class="badge bg-info">{{ entry.dish_category }}</span>
+                {% endif %}
+            </div>
+            <div class="card-footer">
+                <a href="{% url 'content:encyclopedia_detail' entry.slug %}" class="btn btn-primary btn-sm">View Details</a>
+            </div>
+        </div>
+    </div>
+    {% empty %}
+    <div class="col-12">
+        <div class="alert alert-info">
+            No encyclopedia entries found. Create some entries in the admin panel to get started.
+        </div>
+    </div>
+    {% endfor %}
+</div>
+
+<!-- Pagination -->
+{% if is_paginated %}
+<nav aria-label="Page navigation" class="mt-4">
+    <ul class="pagination justify-content-center">
+        {% if page_obj.has_previous %}
+        <li class="page-item">
+            <a class="page-link" href="?page=1" aria-label="First">
+                <span aria-hidden="true">&laquo;&laquo;</span>
+            </a>
+        </li>
+        <li class="page-item">
+            <a class="page-link" href="?page={{ page_obj.previous_page_number }}" aria-label="Previous">
+                <span aria-hidden="true">&laquo;</span>
+            </a>
+        </li>
+        {% else %}
+        <li class="page-item disabled">
+            <span class="page-link">&laquo;&laquo;</span>
+        </li>
+        <li class="page-item disabled">
+            <span class="page-link">&laquo;</span>
+        </li>
+        {% endif %}
+
+        <li class="page-item active">
+            <span class="page-link">
+                Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}
+            </span>
+        </li>
+
+        {% if page_obj.has_next %}
+        <li class="page-item">
+            <a class="page-link" href="?page={{ page_obj.next_page_number }}" aria-label="Next">
+                <span aria-hidden="true">&raquo;</span>
+            </a>
+        </li>
+        <li class="page-item">
+            <a class="page-link" href="?page={{ page_obj.paginator.num_pages }}" aria-label="Last">
+                <span aria-hidden="true">&raquo;&raquo;</span>
+            </a>
+        </li>
+        {% else %}
+        <li class="page-item disabled">
+            <span class="page-link">&raquo;</span>
+        </li>
+        <li class="page-item disabled">
+            <span class="page-link">&raquo;&raquo;</span>
+        </li>
+        {% endif %}
+    </ul>
+</nav>
+{% endif %}
+{% endblock %}


### PR DESCRIPTION
    Implement list and detail views for browsing encyclopedia entries:

    - EncyclopediaListView shows top-level entries with pagination (50/page)
    - EncyclopediaDetailView displays full entry with breadcrumb navigation
    - Created base template with Bootstrap 5.3 and header navigation
    - List template with card grid layout and pagination controls
    - Detail template with images, tags, hierarchy, and related content placeholders
    - Configured URL routing at /encyclopedia/ and /encyclopedia/<slug>/
    - Updated settings to include project-level templates directory

    🤖 Generated with [Claude Code](https://claude.com/claude-code)