### PR TITLE
FT-16: Add Recipe views

### DIFF
--- a/content/urls.py
+++ b/content/urls.py
@@ -9,4 +9,6 @@ urlpatterns = [
     path('encyclopedia/<slug:slug>/', views.EncyclopediaDetailView.as_view(), name='encyclopedia_detail'),
     path('reviews/', views.ReviewListView.as_view(), name='review_list'),
     path('reviews/<int:pk>/', views.ReviewDetailView.as_view(), name='review_detail'),
+    path('recipes/', views.RecipeListView.as_view(), name='recipe_list'),
+    path('recipes/<slug:slug>/', views.RecipeDetailView.as_view(), name='recipe_detail'),
 ]

--- a/content/views/__init__.py
+++ b/content/views/__init__.py
@@ -3,6 +3,8 @@ from .encyclopedia_detail import EncyclopediaDetailView
 from .encyclopedia_search import EncyclopediaSearchView
 from .review_list import ReviewListView
 from .review_detail import ReviewDetailView
+from .recipe_list import RecipeListView
+from .recipe_detail import RecipeDetailView
 
 __all__ = [
     'EncyclopediaListView',
@@ -10,4 +12,6 @@ __all__ = [
     'EncyclopediaSearchView',
     'ReviewListView',
     'ReviewDetailView',
+    'RecipeListView',
+    'RecipeDetailView',
 ]

--- a/content/views/recipe_detail.py
+++ b/content/views/recipe_detail.py
@@ -1,0 +1,44 @@
+from django.views.generic import DetailView
+from content.models import Recipe
+
+
+class RecipeDetailView(DetailView):
+    """
+    Detail view for a single recipe.
+    Displays full recipe details including ingredients, steps, images, tags, and related recipes.
+    """
+    model = Recipe
+    template_name = 'recipe/detail.html'
+    context_object_name = 'recipe'
+    slug_field = 'slug'
+    slug_url_kwarg = 'slug'
+
+    def get_queryset(self):
+        """Only show public recipes."""
+        return Recipe.objects.filter(is_private=False)
+
+    def get_context_data(self, **kwargs):
+        """Add additional context for images, tags, and related recipes."""
+        context = super().get_context_data(**kwargs)
+        recipe = self.object
+
+        # Add images
+        context['images'] = recipe.images.all()
+
+        # Add tags
+        context['tags'] = recipe.recipe_tags.select_related('tag').all()
+
+        # Add related recipes (recipes linked to the same encyclopedia entry, excluding current)
+        if recipe.encyclopedia_entry:
+            context['related_recipes'] = Recipe.objects.filter(
+                encyclopedia_entry=recipe.encyclopedia_entry,
+                is_private=False
+            ).exclude(
+                id=recipe.id
+            ).prefetch_related(
+                'images'
+            ).order_by('name')[:5]
+        else:
+            context['related_recipes'] = []
+
+        return context

--- a/content/views/recipe_list.py
+++ b/content/views/recipe_list.py
@@ -1,0 +1,28 @@
+from django.views.generic import ListView
+from content.models import Recipe
+
+
+class RecipeListView(ListView):
+    """
+    List view for recipes.
+    Shows all public recipes ordered by name with pagination.
+    """
+    model = Recipe
+    template_name = 'recipe/list.html'
+    context_object_name = 'recipes'
+    paginate_by = 50
+
+    def get_queryset(self):
+        """
+        Return all public recipes ordered by name.
+        Optimizes queries with select_related and prefetch_related.
+        """
+        return Recipe.objects.filter(
+            is_private=False
+        ).select_related(
+            'created_by',
+            'encyclopedia_entry'
+        ).prefetch_related(
+            'images',
+            'recipe_tags'
+        ).order_by('name')

--- a/create_test_recipes.py
+++ b/create_test_recipes.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python
+"""
+Script to create test recipe records for FT-16
+"""
+import os
+import django
+
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'config.settings')
+django.setup()
+
+from content.models import Recipe, Encyclopedia
+from django.contrib.auth.models import User
+from django.utils.text import slugify
+
+# Get or create a user
+user, _ = User.objects.get_or_create(
+    username='admin',
+    defaults={'email': 'admin@example.com', 'is_staff': True, 'is_superuser': True}
+)
+
+# Create test recipes
+recipes_data = [
+    {
+        'name': 'Classic Margherita Pizza',
+        'description': 'A simple and delicious pizza with fresh mozzarella, tomatoes, and basil. The perfect introduction to homemade pizza making.',
+        'servings': 4,
+        'prep_time_minutes': 20,
+        'cook_time_minutes': 15,
+        'total_time_minutes': 35,
+        'difficulty': 'easy',
+        'ingredients': [
+            {'item': 'pizza dough', 'quantity': '1 lb', 'notes': 'store-bought or homemade'},
+            {'item': 'tomato sauce', 'quantity': '1 cup', 'notes': 'good quality'},
+            {'item': 'fresh mozzarella', 'quantity': '8 oz', 'notes': 'sliced'},
+            {'item': 'fresh basil leaves', 'quantity': '1/4 cup', 'notes': ''},
+            {'item': 'olive oil', 'quantity': '2 tbsp', 'notes': 'extra virgin'},
+            {'item': 'salt', 'quantity': 'to taste', 'notes': ''},
+        ],
+        'steps': [
+            {'order': 1, 'instruction': 'Preheat oven to 475°F (245°C) with a pizza stone if you have one.', 'time_minutes': 15},
+            {'order': 2, 'instruction': 'Roll out pizza dough on a floured surface to desired thickness.', 'time_minutes': 5},
+            {'order': 3, 'instruction': 'Spread tomato sauce evenly over the dough, leaving a 1-inch border.', 'time_minutes': 2},
+            {'order': 4, 'instruction': 'Distribute mozzarella slices evenly over the sauce.', 'time_minutes': 2},
+            {'order': 5, 'instruction': 'Drizzle with olive oil and season with salt.', 'time_minutes': 1},
+            {'order': 6, 'instruction': 'Bake for 12-15 minutes until crust is golden and cheese is bubbly.', 'time_minutes': 15},
+            {'order': 7, 'instruction': 'Remove from oven, top with fresh basil, slice and serve.', 'time_minutes': 2},
+        ],
+        'tips': 'For best results, use a pizza stone preheated in the oven. If you don\'t have one, use an inverted baking sheet. The key is high heat!',
+        'dietary_restrictions': ['vegetarian'],
+    },
+    {
+        'name': 'Beef Bourguignon',
+        'description': 'A classic French beef stew braised in red wine with carrots, onions, and mushrooms. Rich, hearty, and perfect for special occasions.',
+        'servings': 6,
+        'prep_time_minutes': 30,
+        'cook_time_minutes': 180,
+        'total_time_minutes': 210,
+        'difficulty': 'hard',
+        'ingredients': [
+            {'item': 'beef chuck', 'quantity': '3 lbs', 'notes': 'cut into 2-inch cubes'},
+            {'item': 'red wine', 'quantity': '3 cups', 'notes': 'good quality Burgundy'},
+            {'item': 'pearl onions', 'quantity': '1 lb', 'notes': 'peeled'},
+            {'item': 'carrots', 'quantity': '4 large', 'notes': 'cut into chunks'},
+            {'item': 'mushrooms', 'quantity': '1 lb', 'notes': 'quartered'},
+            {'item': 'bacon', 'quantity': '6 oz', 'notes': 'diced'},
+            {'item': 'tomato paste', 'quantity': '2 tbsp', 'notes': ''},
+            {'item': 'beef stock', 'quantity': '2 cups', 'notes': ''},
+            {'item': 'garlic cloves', 'quantity': '4', 'notes': 'minced'},
+            {'item': 'thyme', 'quantity': '2 sprigs', 'notes': 'fresh'},
+            {'item': 'bay leaves', 'quantity': '2', 'notes': ''},
+            {'item': 'flour', 'quantity': '1/4 cup', 'notes': 'for coating'},
+        ],
+        'steps': [
+            {'order': 1, 'instruction': 'Pat beef dry and season with salt and pepper. Coat lightly with flour.', 'time_minutes': 10},
+            {'order': 2, 'instruction': 'In a Dutch oven, cook bacon until crispy. Remove and set aside.', 'time_minutes': 8},
+            {'order': 3, 'instruction': 'Brown beef in batches in bacon fat. Set aside with bacon.', 'time_minutes': 15},
+            {'order': 4, 'instruction': 'Sauté carrots and onions until golden. Add garlic and tomato paste.', 'time_minutes': 10},
+            {'order': 5, 'instruction': 'Return beef and bacon to pot. Add wine, stock, thyme, and bay leaves.', 'time_minutes': 5},
+            {'order': 6, 'instruction': 'Bring to a boil, cover, and transfer to 325°F oven. Braise for 2.5 hours.', 'time_minutes': 150},
+            {'order': 7, 'instruction': 'Sauté mushrooms separately and add to stew 30 minutes before done.', 'time_minutes': 10},
+            {'order': 8, 'instruction': 'Remove bay leaves and thyme sprigs. Adjust seasoning and serve.', 'time_minutes': 5},
+        ],
+        'tips': 'This dish tastes even better the next day! Make it ahead and reheat gently. Serve with crusty bread or over egg noodles.',
+        'dietary_restrictions': [],
+    },
+    {
+        'name': 'Quick Chicken Stir Fry',
+        'description': 'A fast and healthy weeknight dinner with tender chicken and crisp vegetables in a savory sauce.',
+        'servings': 4,
+        'prep_time_minutes': 15,
+        'cook_time_minutes': 12,
+        'total_time_minutes': 27,
+        'difficulty': 'easy',
+        'ingredients': [
+            {'item': 'chicken breast', 'quantity': '1.5 lbs', 'notes': 'sliced thin'},
+            {'item': 'bell peppers', 'quantity': '2', 'notes': 'sliced'},
+            {'item': 'broccoli florets', 'quantity': '2 cups', 'notes': ''},
+            {'item': 'soy sauce', 'quantity': '3 tbsp', 'notes': ''},
+            {'item': 'oyster sauce', 'quantity': '2 tbsp', 'notes': ''},
+            {'item': 'sesame oil', 'quantity': '1 tbsp', 'notes': ''},
+            {'item': 'ginger', 'quantity': '1 tbsp', 'notes': 'minced'},
+            {'item': 'garlic', 'quantity': '3 cloves', 'notes': 'minced'},
+            {'item': 'cornstarch', 'quantity': '1 tbsp', 'notes': 'mixed with water'},
+            {'item': 'vegetable oil', 'quantity': '2 tbsp', 'notes': 'for cooking'},
+        ],
+        'steps': [
+            {'order': 1, 'instruction': 'Mix soy sauce, oyster sauce, sesame oil, and cornstarch slurry in a bowl.', 'time_minutes': 3},
+            {'order': 2, 'instruction': 'Heat wok or large skillet over high heat. Add oil.', 'time_minutes': 2},
+            {'order': 3, 'instruction': 'Stir-fry chicken until just cooked through, about 4-5 minutes. Remove.', 'time_minutes': 5},
+            {'order': 4, 'instruction': 'Add more oil if needed. Stir-fry vegetables for 3-4 minutes.', 'time_minutes': 4},
+            {'order': 5, 'instruction': 'Add ginger and garlic, cook for 30 seconds until fragrant.', 'time_minutes': 1},
+            {'order': 6, 'instruction': 'Return chicken to wok. Pour in sauce and toss everything together.', 'time_minutes': 2},
+            {'order': 7, 'instruction': 'Cook for another minute until sauce thickens. Serve over rice.', 'time_minutes': 2},
+        ],
+        'tips': 'The key to a good stir fry is high heat and quick cooking. Have all ingredients prepped before you start cooking!',
+        'dietary_restrictions': [],
+    },
+    {
+        'name': 'Vegetarian Pad Thai',
+        'description': 'Thai rice noodles stir-fried with tofu, vegetables, and a tangy tamarind sauce. A satisfying meat-free take on this classic dish.',
+        'servings': 4,
+        'prep_time_minutes': 25,
+        'cook_time_minutes': 15,
+        'total_time_minutes': 40,
+        'difficulty': 'medium',
+        'ingredients': [
+            {'item': 'rice noodles', 'quantity': '8 oz', 'notes': 'flat, medium width'},
+            {'item': 'firm tofu', 'quantity': '14 oz', 'notes': 'pressed and cubed'},
+            {'item': 'bean sprouts', 'quantity': '2 cups', 'notes': ''},
+            {'item': 'green onions', 'quantity': '4', 'notes': 'cut into 2-inch pieces'},
+            {'item': 'eggs', 'quantity': '2', 'notes': 'lightly beaten'},
+            {'item': 'tamarind paste', 'quantity': '3 tbsp', 'notes': ''},
+            {'item': 'fish sauce', 'quantity': '3 tbsp', 'notes': 'or soy sauce for vegan'},
+            {'item': 'brown sugar', 'quantity': '2 tbsp', 'notes': ''},
+            {'item': 'lime', 'quantity': '2', 'notes': 'cut into wedges'},
+            {'item': 'peanuts', 'quantity': '1/2 cup', 'notes': 'crushed'},
+            {'item': 'cilantro', 'quantity': '1/4 cup', 'notes': 'chopped'},
+        ],
+        'steps': [
+            {'order': 1, 'instruction': 'Soak rice noodles in warm water for 30 minutes. Drain.', 'time_minutes': 30},
+            {'order': 2, 'instruction': 'Mix tamarind paste, fish sauce, and brown sugar for the sauce.', 'time_minutes': 3},
+            {'order': 3, 'instruction': 'Heat oil in wok. Fry tofu until golden. Remove and set aside.', 'time_minutes': 5},
+            {'order': 4, 'instruction': 'Scramble eggs in the wok, then push to the side.', 'time_minutes': 2},
+            {'order': 5, 'instruction': 'Add drained noodles and sauce. Stir-fry for 3-4 minutes.', 'time_minutes': 4},
+            {'order': 6, 'instruction': 'Add tofu, bean sprouts, and green onions. Toss to combine.', 'time_minutes': 2},
+            {'order': 7, 'instruction': 'Serve topped with peanuts, cilantro, and lime wedges.', 'time_minutes': 2},
+        ],
+        'tips': 'Don\'t over-soak the noodles - they should still be slightly firm. They\'ll finish cooking in the wok.',
+        'dietary_restrictions': ['vegetarian'],
+    },
+    {
+        'name': 'Chocolate Chip Cookies',
+        'description': 'The perfect chocolate chip cookie - crispy edges, chewy center, and loaded with chocolate chips.',
+        'servings': 24,
+        'prep_time_minutes': 15,
+        'cook_time_minutes': 12,
+        'total_time_minutes': 27,
+        'difficulty': 'easy',
+        'ingredients': [
+            {'item': 'all-purpose flour', 'quantity': '2 1/4 cups', 'notes': ''},
+            {'item': 'butter', 'quantity': '1 cup', 'notes': 'softened'},
+            {'item': 'granulated sugar', 'quantity': '3/4 cup', 'notes': ''},
+            {'item': 'brown sugar', 'quantity': '3/4 cup', 'notes': 'packed'},
+            {'item': 'eggs', 'quantity': '2', 'notes': 'large'},
+            {'item': 'vanilla extract', 'quantity': '2 tsp', 'notes': ''},
+            {'item': 'baking soda', 'quantity': '1 tsp', 'notes': ''},
+            {'item': 'salt', 'quantity': '1 tsp', 'notes': ''},
+            {'item': 'chocolate chips', 'quantity': '2 cups', 'notes': 'semi-sweet'},
+        ],
+        'steps': [
+            {'order': 1, 'instruction': 'Preheat oven to 375°F (190°C).', 'time_minutes': 10},
+            {'order': 2, 'instruction': 'Cream together butter and both sugars until fluffy.', 'time_minutes': 3},
+            {'order': 3, 'instruction': 'Beat in eggs and vanilla extract.', 'time_minutes': 2},
+            {'order': 4, 'instruction': 'In separate bowl, whisk together flour, baking soda, and salt.', 'time_minutes': 2},
+            {'order': 5, 'instruction': 'Gradually mix dry ingredients into wet ingredients.', 'time_minutes': 2},
+            {'order': 6, 'instruction': 'Fold in chocolate chips.', 'time_minutes': 1},
+            {'order': 7, 'instruction': 'Drop rounded tablespoons onto ungreased baking sheets.', 'time_minutes': 5},
+            {'order': 8, 'instruction': 'Bake for 9-11 minutes until golden brown. Cool on baking sheet.', 'time_minutes': 12},
+        ],
+        'tips': 'For chewier cookies, slightly underbake them. They\'ll continue cooking on the hot pan after removal from oven.',
+        'dietary_restrictions': ['vegetarian'],
+    },
+]
+
+print("Creating test recipes...")
+created_count = 0
+
+for recipe_data in recipes_data:
+    slug = slugify(recipe_data['name'])
+
+    # Check if recipe already exists
+    if Recipe.objects.filter(slug=slug).exists():
+        print(f"Recipe '{recipe_data['name']}' already exists, skipping...")
+        continue
+
+    # Create the recipe
+    recipe = Recipe.objects.create(
+        name=recipe_data['name'],
+        slug=slug,
+        description=recipe_data['description'],
+        servings=recipe_data['servings'],
+        prep_time_minutes=recipe_data['prep_time_minutes'],
+        cook_time_minutes=recipe_data['cook_time_minutes'],
+        total_time_minutes=recipe_data['total_time_minutes'],
+        difficulty=recipe_data['difficulty'],
+        ingredients=recipe_data['ingredients'],
+        steps=recipe_data['steps'],
+        tips=recipe_data['tips'],
+        dietary_restrictions=recipe_data['dietary_restrictions'],
+        created_by=user,
+        is_private=False,
+    )
+
+    print(f"[OK] Created recipe: {recipe.name}")
+    created_count += 1
+
+print(f"\nDone! Created {created_count} new recipes.")
+print(f"Total recipes in database: {Recipe.objects.count()}")

--- a/templates/base.html
+++ b/templates/base.html
@@ -25,7 +25,7 @@
                         <a class="nav-link" href="{% url 'content:review_list' %}">Reviews</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="#">Recipes</a>
+                        <a class="nav-link" href="{% url 'content:recipe_list' %}">Recipes</a>
                     </li>
                 </ul>
                 <form class="d-flex" method="get" action="{% url 'content:encyclopedia_search' %}" role="search">

--- a/templates/recipe/detail.html
+++ b/templates/recipe/detail.html
@@ -1,0 +1,221 @@
+{% extends 'base.html' %}
+
+{% block title %}{{ recipe.name }} - Recipes - Food Table{% endblock %}
+
+{% block content %}
+<!-- Breadcrumb Navigation -->
+<nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a href="{% url 'content:recipe_list' %}">Recipes</a></li>
+        <li class="breadcrumb-item active" aria-current="page">{{ recipe.name }}</li>
+    </ol>
+</nav>
+
+<!-- Recipe Header -->
+<div class="row">
+    <div class="col-12">
+        <h1 class="mb-2">{{ recipe.name }}</h1>
+        {% if tags %}
+        <div class="mb-3">
+            {% for tag_obj in tags %}
+            <span class="badge bg-primary me-1 mb-1">{{ tag_obj.tag.name }}</span>
+            {% endfor %}
+        </div>
+        {% endif %}
+        <div class="mb-3">
+            {% if recipe.difficulty == 'easy' %}
+            <span class="badge bg-success me-2">Easy</span>
+            {% elif recipe.difficulty == 'medium' %}
+            <span class="badge bg-warning text-dark me-2">Medium</span>
+            {% elif recipe.difficulty == 'hard' %}
+            <span class="badge bg-danger me-2">Hard</span>
+            {% endif %}
+            {% if recipe.servings %}
+            <span class="badge bg-secondary me-2">{{ recipe.servings }} serving{% if recipe.servings != 1 %}s{% endif %}</span>
+            {% endif %}
+            {% if recipe.dietary_restrictions %}
+                {% for restriction in recipe.dietary_restrictions %}
+                <span class="badge bg-info text-dark me-1">{{ restriction }}</span>
+                {% endfor %}
+            {% endif %}
+        </div>
+        <div class="mb-3">
+            {% if recipe.prep_time_minutes %}
+            <span class="me-3">
+                <strong>Prep Time:</strong> {{ recipe.prep_time_minutes }} min
+            </span>
+            {% endif %}
+            {% if recipe.cook_time_minutes %}
+            <span class="me-3">
+                <strong>Cook Time:</strong> {{ recipe.cook_time_minutes }} min
+            </span>
+            {% endif %}
+            {% if recipe.total_time_minutes %}
+            <span class="me-3">
+                <strong>Total Time:</strong> {{ recipe.total_time_minutes }} min
+            </span>
+            {% endif %}
+        </div>
+        {% if recipe.encyclopedia_entry %}
+        <div class="mb-3">
+            <strong>Related Dish:</strong>
+            <a href="{% url 'content:encyclopedia_detail' recipe.encyclopedia_entry.slug %}">
+                {{ recipe.encyclopedia_entry.name }}
+            </a>
+        </div>
+        {% endif %}
+    </div>
+</div>
+
+<!-- Images Gallery -->
+{% if images %}
+<div class="row mb-4">
+    <div class="col-12">
+        <h3>Photos</h3>
+        <div class="row row-cols-2 row-cols-md-3 row-cols-lg-4 g-3">
+            {% for image in images %}
+            <div class="col">
+                <img src="{{ image.image.url }}" class="img-fluid rounded" alt="{{ image.caption }}" style="width: 100%; height: 200px; object-fit: cover;">
+                {% if image.caption %}
+                <p class="small text-muted mt-1">{{ image.caption }}</p>
+                {% endif %}
+            </div>
+            {% endfor %}
+        </div>
+    </div>
+</div>
+{% endif %}
+
+<!-- Main Content -->
+<div class="row">
+    <div class="col-lg-8">
+        <!-- Description Section -->
+        {% if recipe.description %}
+        <div class="card mb-4">
+            <div class="card-body">
+                <h3 class="card-title">Description</h3>
+                <p class="card-text" style="white-space: pre-line;">{{ recipe.description }}</p>
+            </div>
+        </div>
+        {% endif %}
+
+        <!-- Ingredients Section -->
+        {% if recipe.ingredients %}
+        <div class="card mb-4">
+            <div class="card-body">
+                <h3 class="card-title">Ingredients</h3>
+                <ul class="list-group list-group-flush">
+                    {% for ingredient in recipe.ingredients %}
+                    <li class="list-group-item">
+                        {% if ingredient.quantity %}
+                        <strong>{{ ingredient.quantity }}</strong>
+                        {% endif %}
+                        {{ ingredient.item }}
+                        {% if ingredient.notes %}
+                        <span class="text-muted">({{ ingredient.notes }})</span>
+                        {% endif %}
+                    </li>
+                    {% endfor %}
+                </ul>
+            </div>
+        </div>
+        {% endif %}
+
+        <!-- Steps Section -->
+        {% if recipe.steps %}
+        <div class="card mb-4">
+            <div class="card-body">
+                <h3 class="card-title">Instructions</h3>
+                <ol class="list-group list-group-numbered list-group-flush">
+                    {% for step in recipe.steps %}
+                    <li class="list-group-item">
+                        {{ step.instruction }}
+                        {% if step.time_minutes %}
+                        <span class="badge bg-secondary ms-2">{{ step.time_minutes }} min</span>
+                        {% endif %}
+                    </li>
+                    {% endfor %}
+                </ol>
+            </div>
+        </div>
+        {% endif %}
+
+        <!-- Tips Section -->
+        {% if recipe.tips %}
+        <div class="card mb-4">
+            <div class="card-body">
+                <h3 class="card-title">Tips</h3>
+                <p class="card-text" style="white-space: pre-line;">{{ recipe.tips }}</p>
+            </div>
+        </div>
+        {% endif %}
+    </div>
+
+    <!-- Sidebar -->
+    <div class="col-lg-4">
+        <!-- Metadata -->
+        <div class="card mb-4">
+            <div class="card-body">
+                <h5 class="card-title">Recipe Information</h5>
+                <p class="card-text small">
+                    <strong>Created:</strong> {{ recipe.created_at|date:"M d, Y" }}<br>
+                    <strong>Updated:</strong> {{ recipe.updated_at|date:"M d, Y" }}<br>
+                    {% if recipe.created_by %}
+                    <strong>Author:</strong> {{ recipe.created_by.username }}<br>
+                    {% endif %}
+                    <strong>Version:</strong> {{ recipe.version }}<br>
+                </p>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- Related Recipes -->
+{% if related_recipes %}
+<div class="row mt-4">
+    <div class="col-12">
+        <div class="card">
+            <div class="card-body">
+                <h4 class="card-title">Related Recipes</h4>
+                <p class="text-muted">Other recipes for {{ recipe.encyclopedia_entry.name }}</p>
+                <div class="row row-cols-1 row-cols-md-3 g-3 mt-2">
+                    {% for related in related_recipes %}
+                    <div class="col">
+                        <div class="card">
+                            {% if related.images.all.0 %}
+                            <img src="{{ related.images.all.0.image.url }}" class="card-img-top" alt="{{ related.name }}" style="height: 150px; object-fit: cover;">
+                            {% else %}
+                            <div class="card-img-top bg-light d-flex align-items-center justify-content-center" style="height: 150px;">
+                                <span class="text-muted small">No image</span>
+                            </div>
+                            {% endif %}
+                            <div class="card-body">
+                                <h6 class="card-title">{{ related.name }}</h6>
+                                <div class="mb-2">
+                                    {% if related.difficulty == 'easy' %}
+                                    <span class="badge bg-success">Easy</span>
+                                    {% elif related.difficulty == 'medium' %}
+                                    <span class="badge bg-warning text-dark">Medium</span>
+                                    {% elif related.difficulty == 'hard' %}
+                                    <span class="badge bg-danger">Hard</span>
+                                    {% endif %}
+                                </div>
+                                <a href="{% url 'content:recipe_detail' related.slug %}" class="btn btn-primary btn-sm">View Recipe</a>
+                            </div>
+                        </div>
+                    </div>
+                    {% endfor %}
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+{% endif %}
+
+<!-- Back Button -->
+<div class="row mt-4">
+    <div class="col-12">
+        <a href="{% url 'content:recipe_list' %}" class="btn btn-secondary">Back to Recipes</a>
+    </div>
+</div>
+{% endblock %}

--- a/templates/recipe/list.html
+++ b/templates/recipe/list.html
@@ -1,0 +1,122 @@
+{% extends 'base.html' %}
+
+{% block title %}Recipes - Food Table{% endblock %}
+
+{% block content %}
+<div class="row">
+    <div class="col-12">
+        <h1 class="mb-4">Recipes</h1>
+        <p class="lead">Browse our collection of recipes</p>
+    </div>
+</div>
+
+<!-- Recipes Grid -->
+<div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-4">
+    {% for recipe in recipes %}
+    <div class="col">
+        <div class="card h-100">
+            {% if recipe.images.all.0 %}
+            <img src="{{ recipe.images.all.0.image.url }}" class="card-img-top" alt="{{ recipe.name }}" style="height: 200px; object-fit: cover;">
+            {% else %}
+            <div class="card-img-top bg-light d-flex align-items-center justify-content-center" style="height: 200px;">
+                <span class="text-muted">No image</span>
+            </div>
+            {% endif %}
+            <div class="card-body">
+                <h5 class="card-title">{{ recipe.name }}</h5>
+                <div class="mb-2">
+                    {% if recipe.difficulty == 'easy' %}
+                    <span class="badge bg-success">Easy</span>
+                    {% elif recipe.difficulty == 'medium' %}
+                    <span class="badge bg-warning text-dark">Medium</span>
+                    {% elif recipe.difficulty == 'hard' %}
+                    <span class="badge bg-danger">Hard</span>
+                    {% endif %}
+                    {% if recipe.servings %}
+                    <span class="badge bg-secondary">{{ recipe.servings }} serving{% if recipe.servings != 1 %}s{% endif %}</span>
+                    {% endif %}
+                </div>
+                <p class="card-text text-muted small mb-2">
+                    {% if recipe.total_time_minutes %}
+                    <i class="bi bi-clock"></i> {{ recipe.total_time_minutes }} min
+                    {% elif recipe.prep_time_minutes and recipe.cook_time_minutes %}
+                    <i class="bi bi-clock"></i> {{ recipe.prep_time_minutes|add:recipe.cook_time_minutes }} min
+                    {% elif recipe.prep_time_minutes %}
+                    <i class="bi bi-clock"></i> {{ recipe.prep_time_minutes }} min prep
+                    {% elif recipe.cook_time_minutes %}
+                    <i class="bi bi-clock"></i> {{ recipe.cook_time_minutes }} min cook
+                    {% endif %}
+                </p>
+                {% if recipe.description %}
+                <p class="card-text">
+                    {{ recipe.description|truncatewords:20 }}
+                </p>
+                {% endif %}
+            </div>
+            <div class="card-footer">
+                <a href="{% url 'content:recipe_detail' recipe.slug %}" class="btn btn-primary btn-sm">View Recipe</a>
+            </div>
+        </div>
+    </div>
+    {% empty %}
+    <div class="col-12">
+        <div class="alert alert-info">
+            No recipes found. Create some recipes in the admin panel to get started.
+        </div>
+    </div>
+    {% endfor %}
+</div>
+
+<!-- Pagination -->
+{% if is_paginated %}
+<nav aria-label="Page navigation" class="mt-4">
+    <ul class="pagination justify-content-center">
+        {% if page_obj.has_previous %}
+        <li class="page-item">
+            <a class="page-link" href="?page=1" aria-label="First">
+                <span aria-hidden="true">&laquo;&laquo;</span>
+            </a>
+        </li>
+        <li class="page-item">
+            <a class="page-link" href="?page={{ page_obj.previous_page_number }}" aria-label="Previous">
+                <span aria-hidden="true">&laquo;</span>
+            </a>
+        </li>
+        {% else %}
+        <li class="page-item disabled">
+            <span class="page-link">&laquo;&laquo;</span>
+        </li>
+        <li class="page-item disabled">
+            <span class="page-link">&laquo;</span>
+        </li>
+        {% endif %}
+
+        <li class="page-item active">
+            <span class="page-link">
+                Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}
+            </span>
+        </li>
+
+        {% if page_obj.has_next %}
+        <li class="page-item">
+            <a class="page-link" href="?page={{ page_obj.next_page_number }}" aria-label="Next">
+                <span aria-hidden="true">&raquo;</span>
+            </a>
+        </li>
+        <li class="page-item">
+            <a class="page-link" href="?page={{ page_obj.paginator.num_pages }}" aria-label="Last">
+                <span aria-hidden="true">&raquo;&raquo;</span>
+            </a>
+        </li>
+        {% else %}
+        <li class="page-item disabled">
+            <span class="page-link">&raquo;</span>
+        </li>
+        <li class="page-item disabled">
+            <span class="page-link">&raquo;&raquo;</span>
+        </li>
+        {% endif %}
+    </ul>
+</nav>
+{% endif %}
+{% endblock %}


### PR DESCRIPTION
    Paginate at 50 per page to balance initial load time with
    reducing pagination clicks for browsing large collections.

    Filter to public recipes only to respect privacy settings
    and prevent accidental exposure of private recipes.

    Optimize queries with select_related/prefetch_related to
    avoid N+1 query problems when displaying recipe lists.

    Show related recipes grouped by encyclopedia entry to help
    users discover variations of the same dish.

    🤖 Generated with [Claude Code](https://claude.com/claude-code)

    Co-Authored-By: Claude <noreply@anthropic.com>