### PR TITLE
FT-47: Add review card component

### DIFF
--- a/content/models/review.py
+++ b/content/models/review.py
@@ -68,6 +68,34 @@ class Review(models.Model):
             return f"{self.title} - {self.restaurant_name}"
         return f"{self.restaurant_name} ({self.visit_date})"
 
+    def get_display_image(self):
+        """
+        Get the best image to display for this review.
+
+        Priority:
+        1. First review-level image (if available)
+        2. First image from highest-rated dish (if available)
+        3. None (if no images exist anywhere)
+
+        Returns:
+            Image instance or None
+        """
+        # Try review-level image first
+        review_image = self.images.first()
+        if review_image:
+            return review_image
+
+        # Fall back to highest-rated dish image
+        highest_rated_dish = self.review_dishes.filter(
+            dish_rating__isnull=False,
+            images__isnull=False
+        ).order_by('-dish_rating').first()
+
+        if highest_rated_dish:
+            return highest_rated_dish.images.first()
+
+        return None
+
 
 @receiver(post_save, sender=Review)
 def update_review_search_vector(sender, instance, **kwargs):

--- a/content/views/global_search.py
+++ b/content/views/global_search.py
@@ -64,6 +64,9 @@ class GlobalSearchView(ListView):
                 content_type=Value('review', output_field=CharField())
             ).filter(
                 search_vector=search_query
+            ).prefetch_related(
+                'images',
+                'review_dishes__images'
             ).order_by('-rank')
             results.extend(list(review_results))
 

--- a/content/views/home.py
+++ b/content/views/home.py
@@ -21,7 +21,8 @@ class HomeView(TemplateView):
             'created_by'
         ).prefetch_related(
             'images',
-            'review_dishes'
+            'review_dishes',
+            'review_dishes__images'
         ).order_by('-visit_date', '-entry_time')[:10]
 
         # Calculate stats

--- a/content/views/review_detail.py
+++ b/content/views/review_detail.py
@@ -36,7 +36,8 @@ class ReviewDetailView(DetailView):
         ).exclude(
             id=review.id
         ).prefetch_related(
-            'images'
+            'images',
+            'review_dishes__images'
         ).order_by('-visit_date', '-entry_time')[:5]
 
         return context

--- a/content/views/review_list.py
+++ b/content/views/review_list.py
@@ -22,5 +22,6 @@ class ReviewListView(ListView):
         ).select_related(
             'created_by'
         ).prefetch_related(
-            'images'
+            'images',
+            'review_dishes__images'
         ).order_by('-visit_date', '-entry_time')

--- a/templates/components/review_card.html
+++ b/templates/components/review_card.html
@@ -1,0 +1,43 @@
+{% load review_tags %}
+
+{# Component: Review Card #}
+{# Parameters: review (required) #}
+
+<div class="card h-100">
+    {# Image with fallback #}
+    {% with display_image=review.get_display_image %}
+        {% if display_image %}
+        <img src="{{ display_image.image.url }}"
+             class="card-img-top"
+             alt="{{ review.restaurant_name }}"
+             style="height: 200px; object-fit: cover;">
+        {% else %}
+        <div class="card-img-top bg-light d-flex align-items-center justify-content-center"
+             style="height: 200px;">
+            <span class="text-muted">No image</span>
+        </div>
+        {% endif %}
+    {% endwith %}
+
+    <div class="card-body">
+        <h5 class="card-title">{{ review.restaurant_name }}</h5>
+        <p class="card-text text-muted mb-2">
+            <small>{{ review.visit_date|date:"F d, Y" }}</small>
+            {% if review.location %}
+            <br><small>{{ review.location }}</small>
+            {% endif %}
+        </p>
+        <div class="mb-2">
+            {{ review.rating|rating_to_stars }}
+        </div>
+        {% if review.notes %}
+        <p class="card-text">
+            {{ review.notes|truncatewords:15 }}
+        </p>
+        {% endif %}
+    </div>
+
+    <div class="card-footer">
+        <a href="{% url 'content:review_detail' review.pk %}" class="btn btn-primary btn-sm">View Details</a>
+    </div>
+</div>

--- a/templates/home.html
+++ b/templates/home.html
@@ -95,35 +95,7 @@
 <div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-4 mb-4">
     {% for review in recent_reviews %}
     <div class="col">
-        <div class="card h-100">
-            {% if review.images.all.0 %}
-            <img src="{{ review.images.all.0.image.url }}" class="card-img-top" alt="{{ review.restaurant_name }}" style="height: 200px; object-fit: cover;">
-            {% else %}
-            <div class="card-img-top bg-light d-flex align-items-center justify-content-center" style="height: 200px;">
-                <span class="text-muted">No image</span>
-            </div>
-            {% endif %}
-            <div class="card-body">
-                <h5 class="card-title">{{ review.restaurant_name }}</h5>
-                <p class="card-text text-muted mb-2">
-                    <small>{{ review.visit_date|date:"F d, Y" }}</small>
-                    {% if review.location %}
-                    <br><small>{{ review.location }}</small>
-                    {% endif %}
-                </p>
-                <div class="mb-2">
-                    {{ review.rating|rating_to_stars }}
-                </div>
-                {% if review.notes %}
-                <p class="card-text">
-                    {{ review.notes|truncatewords:15 }}
-                </p>
-                {% endif %}
-            </div>
-            <div class="card-footer">
-                <a href="{% url 'content:review_detail' review.pk %}" class="btn btn-primary btn-sm">View Details</a>
-            </div>
-        </div>
+        {% include 'components/review_card.html' with review=review %}
     </div>
     {% endfor %}
 </div>

--- a/templates/review/detail.html
+++ b/templates/review/detail.html
@@ -167,27 +167,10 @@
         <div class="card">
             <div class="card-body">
                 <h4 class="card-title">Other Reviews at {{ review.restaurant_name }}</h4>
-                <div class="row row-cols-1 row-cols-md-3 g-3 mt-2">
+                <div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-4 mt-2">
                     {% for related in related_reviews %}
                     <div class="col">
-                        <div class="card">
-                            {% if related.images.all.0 %}
-                            <img src="{{ related.images.all.0.image.url }}" class="card-img-top" alt="{{ related.restaurant_name }}" style="height: 150px; object-fit: cover;">
-                            {% else %}
-                            <div class="card-img-top bg-light d-flex align-items-center justify-content-center" style="height: 150px;">
-                                <span class="text-muted small">No image</span>
-                            </div>
-                            {% endif %}
-                            <div class="card-body">
-                                <p class="card-text small text-muted mb-2">
-                                    {{ related.visit_date|date:"M d, Y" }}
-                                </p>
-                                <div class="mb-2">
-                                    {{ related.rating|rating_to_stars }}
-                                </div>
-                                <a href="{% url 'content:review_detail' related.pk %}" class="btn btn-primary btn-sm">View Review</a>
-                            </div>
-                        </div>
+                        {% include 'components/review_card.html' with review=related %}
                     </div>
                     {% endfor %}
                 </div>

--- a/templates/review/list.html
+++ b/templates/review/list.html
@@ -15,35 +15,7 @@
 <div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-4">
     {% for review in reviews %}
     <div class="col">
-        <div class="card h-100">
-            {% if review.images.all.0 %}
-            <img src="{{ review.images.all.0.image.url }}" class="card-img-top" alt="{{ review.restaurant_name }}" style="height: 200px; object-fit: cover;">
-            {% else %}
-            <div class="card-img-top bg-light d-flex align-items-center justify-content-center" style="height: 200px;">
-                <span class="text-muted">No image</span>
-            </div>
-            {% endif %}
-            <div class="card-body">
-                <h5 class="card-title">{{ review.restaurant_name }}</h5>
-                <p class="card-text text-muted mb-2">
-                    <small>{{ review.visit_date|date:"F d, Y" }}</small>
-                    {% if review.location %}
-                    <br><small>{{ review.location }}</small>
-                    {% endif %}
-                </p>
-                <div class="mb-2">
-                    {{ review.rating|rating_to_stars }}
-                </div>
-                {% if review.notes %}
-                <p class="card-text">
-                    {{ review.notes|truncatewords:15 }}
-                </p>
-                {% endif %}
-            </div>
-            <div class="card-footer">
-                <a href="{% url 'content:review_detail' review.pk %}" class="btn btn-primary btn-sm">View Details</a>
-            </div>
-        </div>
+        {% include 'components/review_card.html' with review=review %}
     </div>
     {% empty %}
     <div class="col-12">

--- a/templates/search/results.html
+++ b/templates/search/results.html
@@ -82,9 +82,21 @@
             </div>
 
             <!-- Image -->
-            {% if result.images.all.0 %}
+            {% if result.content_type == 'review' %}
+                {% with display_image=result.get_display_image %}
+                    {% if display_image %}
+                    <img src="{{ display_image.image.url }}" class="card-img-top"
+                         alt="{{ result.restaurant_name }}"
+                         style="height: 200px; object-fit: cover;">
+                    {% else %}
+                    <div class="card-img-top bg-light d-flex align-items-center justify-content-center" style="height: 200px;">
+                        <span class="text-muted">No image</span>
+                    </div>
+                    {% endif %}
+                {% endwith %}
+            {% elif result.images.all.0 %}
             <img src="{{ result.images.all.0.image.url }}" class="card-img-top"
-                 alt="{% if result.content_type == 'encyclopedia' or result.content_type == 'recipe' %}{{ result.name }}{% elif result.content_type == 'review' %}{{ result.restaurant_name }}{% endif %}"
+                 alt="{% if result.content_type == 'encyclopedia' or result.content_type == 'recipe' %}{{ result.name }}{% endif %}"
                  style="height: 200px; object-fit: cover;">
             {% else %}
             <div class="card-img-top bg-light d-flex align-items-center justify-content-center" style="height: 200px;">


### PR DESCRIPTION
Extract review card markup into reusable component to eliminate duplication across home, list, detail, and search result pages.

Add get_display_image() method to Review model. Falls back to highest-rated dish image when review has no direct images.

Prefetch dish images in views to prevent N+1 queries when displaying fallback images.

🤖 Generated with [Claude Code](https://claude.com/claude-code)