### PR TITLE
FT-48: Add reusable admin edit button component

### DIFF
--- a/content/templatetags/admin_tags.py
+++ b/content/templatetags/admin_tags.py
@@ -1,0 +1,38 @@
+from django import template
+from django.urls import reverse
+from django.contrib.contenttypes.models import ContentType
+
+register = template.Library()
+
+
+@register.inclusion_tag('components/admin_edit_button.html', takes_context=True)
+def admin_edit_button(context, obj, button_text="Edit"):
+    """
+    Renders an edit button linking to Django admin for the given object.
+    Only visible to staff users.
+
+    Args:
+        context: Template context (automatically passed)
+        obj: The model instance to generate an admin edit link for
+        button_text: Text to display on the button (default: "Edit")
+
+    Returns:
+        Dictionary with button context variables
+    """
+    user = context['request'].user
+
+    if not user.is_staff:
+        return {'show_button': False}
+
+    content_type = ContentType.objects.get_for_model(obj)
+    admin_url = reverse(
+        f'admin:{content_type.app_label}_{content_type.model}_change',
+        args=[obj.pk]
+    )
+
+    return {
+        'show_button': True,
+        'admin_url': admin_url,
+        'button_text': button_text,
+        'object_name': content_type.model
+    }

--- a/templates/base.html
+++ b/templates/base.html
@@ -6,6 +6,8 @@
     <title>{% block title %}Food Table{% endblock %}</title>
     <!-- Bootstrap CSS -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <!-- Bootstrap Icons -->
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.0/font/bootstrap-icons.css" rel="stylesheet">
     {% block extra_css %}{% endblock %}
 </head>
 <body>

--- a/templates/components/admin_edit_button.html
+++ b/templates/components/admin_edit_button.html
@@ -1,0 +1,8 @@
+{% if show_button %}
+<a href="{{ admin_url }}"
+   class="btn btn-outline-secondary btn-sm"
+   target="_blank"
+   aria-label="Edit {{ object_name }} in admin">
+    <i class="bi bi-pencil-square"></i> {{ button_text }}
+</a>
+{% endif %}

--- a/templates/encyclopedia/detail.html
+++ b/templates/encyclopedia/detail.html
@@ -1,4 +1,5 @@
 {% extends 'base.html' %}
+{% load admin_tags %}
 
 {% block title %}{{ entry.name }} - Encyclopedia - Food Table{% endblock %}
 
@@ -19,7 +20,10 @@
 <!-- Entry Header -->
 <div class="row">
     <div class="col-12">
-        <h1 class="mb-3">{{ entry.name }}</h1>
+        <div class="d-flex justify-content-between align-items-center mb-3">
+            <h1 class="mb-0">{{ entry.name }}</h1>
+            {% admin_edit_button entry %}
+        </div>
         <div class="mb-3">
             {% if entry.cuisine_type %}
             <span class="badge bg-secondary">{{ entry.cuisine_type }}</span>

--- a/templates/recipe/detail.html
+++ b/templates/recipe/detail.html
@@ -1,4 +1,5 @@
 {% extends 'base.html' %}
+{% load admin_tags %}
 
 {% block title %}{{ recipe.name }} - Recipes - Food Table{% endblock %}
 
@@ -14,7 +15,10 @@
 <!-- Recipe Header -->
 <div class="row">
     <div class="col-12">
-        <h1 class="mb-2">{{ recipe.name }}</h1>
+        <div class="d-flex justify-content-between align-items-center mb-2">
+            <h1 class="mb-0">{{ recipe.name }}</h1>
+            {% admin_edit_button recipe %}
+        </div>
         {% if tags %}
         <div class="mb-3">
             {% for tag_obj in tags %}

--- a/templates/review/detail.html
+++ b/templates/review/detail.html
@@ -1,5 +1,6 @@
 {% extends 'base.html' %}
 {% load review_tags %}
+{% load admin_tags %}
 
 {% block title %}{{ review.restaurant_name }} - Reviews - Food Table{% endblock %}
 
@@ -15,7 +16,10 @@
 <!-- Review Header -->
 <div class="row">
     <div class="col-12">
-        <h1 class="mb-2">{{ review.restaurant_name }}</h1>
+        <div class="d-flex justify-content-between align-items-center mb-2">
+            <h1 class="mb-0">{{ review.restaurant_name }}</h1>
+            {% admin_edit_button review %}
+        </div>
         {% if review.title %}
         <p class="lead text-muted mb-3">{{ review.title }}</p>
         {% endif %}


### PR DESCRIPTION
    Create template tag and component for quick admin
    access from detail pages. Staff users can now edit
    content in-place via pencil icon in page header.

    Add Bootstrap Icons CDN to support pencil icon.

    🤖 Generated with [Claude Code](https://claude.com/claude-code)

    Co-Authored-By: Claude <noreply@anthropic.com>