### PR TITLE
FT-57: Add recursive tree rendering

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -127,6 +127,7 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/5.2/howto/static-files/
 
 STATIC_URL = 'static/'
+STATICFILES_DIRS = [BASE_DIR / 'static']
 
 # Media files
 MEDIA_ROOT = BASE_DIR / 'media'

--- a/content/views/encyclopedia_list.py
+++ b/content/views/encyclopedia_list.py
@@ -34,9 +34,16 @@ class EncyclopediaListView(ListView):
         """Add additional context for tree view."""
         context = super().get_context_data(**kwargs)
 
-        # Annotate each entry with computed properties for template
-        for entry in context['entries']:
+        # Recursively annotate all entries (including children) with computed properties
+        def annotate_entry(entry):
             entry.depth = entry.get_depth()
             entry.has_children = entry.children.exists()
+            # Recursively annotate children
+            for child in entry.children.all():
+                annotate_entry(child)
+
+        # Annotate root entries and all their descendants
+        for entry in context['entries']:
+            annotate_entry(entry)
 
         return context

--- a/content/views/encyclopedia_list.py
+++ b/content/views/encyclopedia_list.py
@@ -1,18 +1,42 @@
 from django.views.generic import ListView
+from django.db.models import Count
 from content.models import Encyclopedia
 
 
 class EncyclopediaListView(ListView):
     """
-    List view for encyclopedia entries.
-    Shows all encyclopedia entries (including hierarchical children) with pagination.
-    Optimized with select_related/prefetch_related to prevent N+1 queries.
+    Tree view for encyclopedia entries.
+    Shows root-level encyclopedia entries with hierarchical structure.
+    Child entries are accessible via the tree expansion UI.
     """
     model = Encyclopedia
     template_name = 'encyclopedia/list.html'
     context_object_name = 'entries'
-    paginate_by = 50
+    paginate_by = None  # No pagination for tree view - show all roots
 
     def get_queryset(self):
-        """Return all encyclopedia entries with optimized parent/child queries, ordered by name."""
-        return Encyclopedia.objects.select_related('parent').prefetch_related('children').order_by('name')
+        """
+        Return only root encyclopedia entries (no parent) with:
+        - Optimized queries for children relationships
+        - Annotated with children count
+        - Ordered by name
+        """
+        return (
+            Encyclopedia.objects
+            .filter(parent__isnull=True)  # Only root entries
+            .select_related('parent')
+            .prefetch_related('children')
+            .annotate(children_count=Count('children'))
+            .order_by('name')
+        )
+
+    def get_context_data(self, **kwargs):
+        """Add additional context for tree view."""
+        context = super().get_context_data(**kwargs)
+
+        # Annotate each entry with computed properties for template
+        for entry in context['entries']:
+            entry.depth = entry.get_depth()
+            entry.has_children = entry.children.exists()
+
+        return context

--- a/static/css/encyclopedia_tree.css
+++ b/static/css/encyclopedia_tree.css
@@ -1,0 +1,277 @@
+/* Encyclopedia Tree View Styles */
+
+/* Tree Container */
+.encyclopedia-tree {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.encyclopedia-tree ul {
+    list-style: none;
+    padding-left: 0;
+    margin: 0;
+}
+
+/* Tree Entry Base Styles */
+.tree-entry {
+    position: relative;
+    margin-bottom: 0.5rem;
+    border-radius: 0.375rem;
+    transition: all 0.2s ease;
+}
+
+.tree-entry-content {
+    display: flex;
+    align-items: center;
+    padding: 0.75rem 1rem;
+    min-height: 44px; /* WCAG mobile touch target */
+    gap: 0.75rem;
+}
+
+.tree-entry:hover {
+    transform: translateX(2px);
+}
+
+/* Depth-Based Color Coding (WCAG AA Compliant) */
+.tree-entry[data-depth="0"] {
+    border-left: 4px solid #1e40af; /* Deep Blue */
+    background: rgba(30, 64, 175, 0.05);
+}
+
+.tree-entry[data-depth="0"]:hover {
+    background: rgba(30, 64, 175, 0.1);
+}
+
+.tree-entry[data-depth="1"] {
+    border-left: 4px solid #059669; /* Green */
+    background: rgba(5, 150, 105, 0.05);
+    margin-left: 1.5rem;
+}
+
+.tree-entry[data-depth="1"]:hover {
+    background: rgba(5, 150, 105, 0.1);
+}
+
+.tree-entry[data-depth="2"] {
+    border-left: 4px solid #d97706; /* Amber */
+    background: rgba(217, 119, 6, 0.05);
+    margin-left: 3rem;
+}
+
+.tree-entry[data-depth="2"]:hover {
+    background: rgba(217, 119, 6, 0.1);
+}
+
+.tree-entry[data-depth="3"],
+.tree-entry[data-depth="4"],
+.tree-entry[data-depth="5"],
+.tree-entry[data-depth="6"],
+.tree-entry[data-depth="7"],
+.tree-entry[data-depth="8"],
+.tree-entry[data-depth="9"] {
+    border-left: 4px solid #6b7280; /* Gray */
+    background: rgba(107, 114, 128, 0.05);
+}
+
+.tree-entry[data-depth="3"]:hover,
+.tree-entry[data-depth="4"]:hover,
+.tree-entry[data-depth="5"]:hover,
+.tree-entry[data-depth="6"]:hover,
+.tree-entry[data-depth="7"]:hover,
+.tree-entry[data-depth="8"]:hover,
+.tree-entry[data-depth="9"]:hover {
+    background: rgba(107, 114, 128, 0.1);
+}
+
+.tree-entry[data-depth="3"] { margin-left: 4.5rem; }
+.tree-entry[data-depth="4"] { margin-left: 6rem; }
+.tree-entry[data-depth="5"] { margin-left: 7.5rem; }
+.tree-entry[data-depth="6"] { margin-left: 9rem; }
+.tree-entry[data-depth="7"] { margin-left: 10.5rem; }
+.tree-entry[data-depth="8"] { margin-left: 12rem; }
+.tree-entry[data-depth="9"] { margin-left: 13.5rem; }
+
+/* Expand/Collapse Button */
+.tree-toggle {
+    background: none;
+    border: none;
+    padding: 0.5rem;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 44px;
+    min-height: 44px;
+    border-radius: 0.25rem;
+    color: #4b5563;
+    transition: all 0.2s ease;
+}
+
+.tree-toggle:hover {
+    background: rgba(0, 0, 0, 0.05);
+    color: #1f2937;
+}
+
+.tree-toggle:focus {
+    outline: 2px solid #2563eb;
+    outline-offset: 2px;
+}
+
+.tree-toggle i {
+    font-size: 1rem;
+    transition: transform 0.2s ease;
+}
+
+/* Placeholder for entries without children */
+.tree-toggle-placeholder {
+    min-width: 44px;
+    min-height: 44px;
+}
+
+/* Entry Icons */
+.tree-icon {
+    font-size: 1.25rem;
+    min-width: 1.5rem;
+    text-align: center;
+    color: #6b7280;
+}
+
+.tree-icon.folder-icon {
+    color: #d97706;
+}
+
+.tree-icon.leaf-icon {
+    color: #3b82f6;
+}
+
+/* Entry Name Link */
+.tree-entry-link {
+    flex: 1;
+    text-decoration: none;
+    color: #1f2937;
+    font-weight: 500;
+    font-size: 1rem;
+    line-height: 1.5;
+}
+
+.tree-entry-link:hover {
+    color: #2563eb;
+    text-decoration: underline;
+}
+
+.tree-entry-link:focus {
+    outline: 2px solid #2563eb;
+    outline-offset: 2px;
+    border-radius: 0.25rem;
+}
+
+/* Child Count Badge */
+.child-count-badge {
+    background: #e5e7eb;
+    color: #374151;
+    padding: 0.25rem 0.5rem;
+    border-radius: 9999px;
+    font-size: 0.75rem;
+    font-weight: 600;
+    min-width: 24px;
+    text-align: center;
+}
+
+/* Children Container */
+.tree-children {
+    margin-top: 0.25rem;
+}
+
+.tree-children.collapsed {
+    display: none;
+}
+
+/* Control Buttons */
+.tree-controls {
+    display: flex;
+    gap: 0.75rem;
+    margin-bottom: 1.5rem;
+    flex-wrap: wrap;
+}
+
+.tree-control-btn {
+    padding: 0.5rem 1rem;
+    border: 1px solid #d1d5db;
+    background: white;
+    color: #374151;
+    border-radius: 0.375rem;
+    font-size: 0.875rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    min-height: 44px;
+}
+
+.tree-control-btn:hover {
+    background: #f3f4f6;
+    border-color: #9ca3af;
+}
+
+.tree-control-btn:focus {
+    outline: 2px solid #2563eb;
+    outline-offset: 2px;
+}
+
+.tree-control-btn i {
+    margin-right: 0.5rem;
+}
+
+/* Mobile Responsive Adjustments */
+@media (max-width: 768px) {
+    /* Reduce indentation on mobile */
+    .tree-entry[data-depth="1"] { margin-left: 1rem; }
+    .tree-entry[data-depth="2"] { margin-left: 2rem; }
+    .tree-entry[data-depth="3"] { margin-left: 3rem; }
+    .tree-entry[data-depth="4"] { margin-left: 4rem; }
+    .tree-entry[data-depth="5"] { margin-left: 5rem; }
+    .tree-entry[data-depth="6"] { margin-left: 6rem; }
+    .tree-entry[data-depth="7"] { margin-left: 7rem; }
+    .tree-entry[data-depth="8"] { margin-left: 8rem; }
+    .tree-entry[data-depth="9"] { margin-left: 9rem; }
+
+    .tree-entry-content {
+        padding: 0.5rem 0.75rem;
+        gap: 0.5rem;
+    }
+
+    .tree-entry-link {
+        font-size: 0.875rem;
+    }
+
+    .tree-icon {
+        font-size: 1rem;
+    }
+}
+
+/* Accessibility: High Contrast Mode Support */
+@media (prefers-contrast: high) {
+    .tree-entry[data-depth="0"] {
+        border-left-width: 6px;
+    }
+
+    .tree-entry[data-depth="1"],
+    .tree-entry[data-depth="2"],
+    .tree-entry[data-depth="3"] {
+        border-left-width: 5px;
+    }
+}
+
+/* Accessibility: Reduced Motion */
+@media (prefers-reduced-motion: reduce) {
+    .tree-entry,
+    .tree-toggle,
+    .tree-toggle i,
+    .tree-control-btn {
+        transition: none;
+    }
+
+    .tree-entry:hover {
+        transform: none;
+    }
+}

--- a/templates/encyclopedia/list.html
+++ b/templates/encyclopedia/list.html
@@ -1,103 +1,88 @@
 {% extends 'base.html' %}
+{% load static %}
 
 {% block title %}Encyclopedia - Food Table{% endblock %}
+
+{% block extra_css %}
+<link rel="stylesheet" href="{% static 'css/encyclopedia_tree.css' %}">
+{% endblock %}
 
 {% block content %}
 <div class="row">
     <div class="col-12">
         <h1 class="mb-4">Encyclopedia</h1>
-        <p class="lead">Browse our collection of food knowledge entries</p>
+        <p class="lead">Browse our hierarchical collection of food knowledge entries</p>
     </div>
 </div>
 
-<!-- Entries Grid -->
-<div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-4">
-    {% for entry in entries %}
-    <div class="col">
-        <div class="card h-100">
-            {% if entry.images.all.0 %}
-            <img src="{{ entry.images.all.0.image.url }}" class="card-img-top" alt="{{ entry.name }}" style="height: 200px; object-fit: cover;">
-            {% else %}
-            <div class="card-img-top bg-light d-flex align-items-center justify-content-center" style="height: 200px;">
-                <span class="text-muted">No image</span>
+{% if entries %}
+<!-- Tree Controls -->
+<div class="tree-controls">
+    <button type="button" class="tree-control-btn" id="expand-all-btn" aria-label="Expand all entries">
+        <i class="bi bi-arrows-expand" aria-hidden="true"></i>
+        Expand All
+    </button>
+    <button type="button" class="tree-control-btn" id="collapse-all-btn" aria-label="Collapse all entries">
+        <i class="bi bi-arrows-collapse" aria-hidden="true"></i>
+        Collapse All
+    </button>
+</div>
+
+<!-- Tree View -->
+<div role="tree" aria-label="Encyclopedia entries hierarchical view">
+    <ul class="encyclopedia-tree">
+        {% for entry in entries %}
+        <li class="tree-entry" data-depth="{{ entry.depth }}" role="treeitem" aria-expanded="false">
+            <div class="tree-entry-content">
+                <!-- Expand/Collapse Toggle or Placeholder -->
+                {% if entry.has_children %}
+                <button type="button"
+                        class="tree-toggle"
+                        aria-label="Expand {{ entry.name }}"
+                        data-entry-id="{{ entry.id }}">
+                    <i class="bi bi-chevron-right" aria-hidden="true"></i>
+                </button>
+                {% else %}
+                <div class="tree-toggle-placeholder" aria-hidden="true"></div>
+                {% endif %}
+
+                <!-- Entry Icon -->
+                {% if entry.has_children %}
+                <i class="bi bi-folder tree-icon folder-icon" aria-hidden="true"></i>
+                {% else %}
+                <i class="bi bi-file-text tree-icon leaf-icon" aria-hidden="true"></i>
+                {% endif %}
+
+                <!-- Entry Name (Link) -->
+                <a href="{% url 'content:encyclopedia_detail' entry.slug %}"
+                   class="tree-entry-link">
+                    {{ entry.name }}
+                </a>
+
+                <!-- Child Count Badge -->
+                {% if entry.has_children %}
+                <span class="child-count-badge"
+                      aria-label="{{ entry.children_count }} child entries">
+                    {{ entry.children_count }}
+                </span>
+                {% endif %}
+            </div>
+
+            <!-- Children Container (Initially Collapsed) -->
+            {% if entry.has_children %}
+            <div class="tree-children collapsed"
+                 id="children-{{ entry.id }}"
+                 role="group">
+                <!-- Children will be loaded here (future JS implementation) -->
             </div>
             {% endif %}
-            <div class="card-body">
-                <h5 class="card-title">{{ entry.name }}</h5>
-                <p class="card-text">
-                    {{ entry.description|truncatewords:20 }}
-                </p>
-                {% if entry.cuisine_type %}
-                <span class="badge bg-secondary">{{ entry.cuisine_type }}</span>
-                {% endif %}
-                {% if entry.dish_category %}
-                <span class="badge bg-info">{{ entry.dish_category }}</span>
-                {% endif %}
-            </div>
-            <div class="card-footer">
-                <a href="{% url 'content:encyclopedia_detail' entry.slug %}" class="btn btn-primary btn-sm">View Details</a>
-            </div>
-        </div>
-    </div>
-    {% empty %}
-    <div class="col-12">
-        <div class="alert alert-info">
-            No encyclopedia entries found. Create some entries in the admin panel to get started.
-        </div>
-    </div>
-    {% endfor %}
-</div>
-
-<!-- Pagination -->
-{% if is_paginated %}
-<nav aria-label="Page navigation" class="mt-4">
-    <ul class="pagination justify-content-center">
-        {% if page_obj.has_previous %}
-        <li class="page-item">
-            <a class="page-link" href="?page=1" aria-label="First">
-                <span aria-hidden="true">&laquo;&laquo;</span>
-            </a>
         </li>
-        <li class="page-item">
-            <a class="page-link" href="?page={{ page_obj.previous_page_number }}" aria-label="Previous">
-                <span aria-hidden="true">&laquo;</span>
-            </a>
-        </li>
-        {% else %}
-        <li class="page-item disabled">
-            <span class="page-link">&laquo;&laquo;</span>
-        </li>
-        <li class="page-item disabled">
-            <span class="page-link">&laquo;</span>
-        </li>
-        {% endif %}
-
-        <li class="page-item active">
-            <span class="page-link">
-                Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}
-            </span>
-        </li>
-
-        {% if page_obj.has_next %}
-        <li class="page-item">
-            <a class="page-link" href="?page={{ page_obj.next_page_number }}" aria-label="Next">
-                <span aria-hidden="true">&raquo;</span>
-            </a>
-        </li>
-        <li class="page-item">
-            <a class="page-link" href="?page={{ page_obj.paginator.num_pages }}" aria-label="Last">
-                <span aria-hidden="true">&raquo;&raquo;</span>
-            </a>
-        </li>
-        {% else %}
-        <li class="page-item disabled">
-            <span class="page-link">&raquo;</span>
-        </li>
-        <li class="page-item disabled">
-            <span class="page-link">&raquo;&raquo;</span>
-        </li>
-        {% endif %}
+        {% endfor %}
     </ul>
-</nav>
+</div>
+{% else %}
+<div class="alert alert-info">
+    No encyclopedia entries found. Create some entries in the admin panel to get started.
+</div>
 {% endif %}
 {% endblock %}

--- a/templates/encyclopedia/list.html
+++ b/templates/encyclopedia/list.html
@@ -32,51 +32,7 @@
 <div role="tree" aria-label="Encyclopedia entries hierarchical view">
     <ul class="encyclopedia-tree">
         {% for entry in entries %}
-        <li class="tree-entry" data-depth="{{ entry.depth }}" role="treeitem" aria-expanded="false">
-            <div class="tree-entry-content">
-                <!-- Expand/Collapse Toggle or Placeholder -->
-                {% if entry.has_children %}
-                <button type="button"
-                        class="tree-toggle"
-                        aria-label="Expand {{ entry.name }}"
-                        data-entry-id="{{ entry.id }}">
-                    <i class="bi bi-chevron-right" aria-hidden="true"></i>
-                </button>
-                {% else %}
-                <div class="tree-toggle-placeholder" aria-hidden="true"></div>
-                {% endif %}
-
-                <!-- Entry Icon -->
-                {% if entry.has_children %}
-                <i class="bi bi-folder tree-icon folder-icon" aria-hidden="true"></i>
-                {% else %}
-                <i class="bi bi-file-text tree-icon leaf-icon" aria-hidden="true"></i>
-                {% endif %}
-
-                <!-- Entry Name (Link) -->
-                <a href="{% url 'content:encyclopedia_detail' entry.slug %}"
-                   class="tree-entry-link">
-                    {{ entry.name }}
-                </a>
-
-                <!-- Child Count Badge -->
-                {% if entry.has_children %}
-                <span class="child-count-badge"
-                      aria-label="{{ entry.children_count }} child entries">
-                    {{ entry.children_count }}
-                </span>
-                {% endif %}
-            </div>
-
-            <!-- Children Container (Initially Collapsed) -->
-            {% if entry.has_children %}
-            <div class="tree-children collapsed"
-                 id="children-{{ entry.id }}"
-                 role="group">
-                <!-- Children will be loaded here (future JS implementation) -->
-            </div>
-            {% endif %}
-        </li>
+            {% include 'encyclopedia/tree_node.html' with entry=entry %}
         {% endfor %}
     </ul>
 </div>

--- a/templates/encyclopedia/tree_node.html
+++ b/templates/encyclopedia/tree_node.html
@@ -1,0 +1,49 @@
+<li class="tree-entry" data-depth="{{ entry.depth }}" role="treeitem" aria-expanded="false">
+    <div class="tree-entry-content">
+        <!-- Expand/Collapse Toggle or Placeholder -->
+        {% if entry.has_children %}
+        <button type="button"
+                class="tree-toggle"
+                aria-label="Expand {{ entry.name }}"
+                data-entry-id="{{ entry.id }}">
+            <i class="bi bi-chevron-right" aria-hidden="true"></i>
+        </button>
+        {% else %}
+        <div class="tree-toggle-placeholder" aria-hidden="true"></div>
+        {% endif %}
+
+        <!-- Entry Icon -->
+        {% if entry.has_children %}
+        <i class="bi bi-folder tree-icon folder-icon" aria-hidden="true"></i>
+        {% else %}
+        <i class="bi bi-file-text tree-icon leaf-icon" aria-hidden="true"></i>
+        {% endif %}
+
+        <!-- Entry Name (Link) -->
+        <a href="{% url 'content:encyclopedia_detail' entry.slug %}"
+           class="tree-entry-link">
+            {{ entry.name }}
+        </a>
+
+        <!-- Child Count Badge -->
+        {% if entry.has_children %}
+        <span class="child-count-badge"
+              aria-label="{{ entry.children_count }} child entries">
+            {{ entry.children_count }}
+        </span>
+        {% endif %}
+    </div>
+
+    <!-- Children Container (Initially Collapsed) -->
+    {% if entry.has_children %}
+    <div class="tree-children collapsed"
+         id="children-{{ entry.id }}"
+         role="group">
+        <ul>
+            {% for child in entry.children.all %}
+                {% include 'encyclopedia/tree_node.html' with entry=child %}
+            {% endfor %}
+        </ul>
+    </div>
+    {% endif %}
+</li>


### PR DESCRIPTION
    Implement recursive template pattern to render full
    tree hierarchy. Extract tree node markup to reusable
    template that calls itself for children.

    Update view to recursively annotate entire tree with
    depth and has_children attributes needed for styling.

    🤖 Generated with [Claude Code](https://claude.com/claude-code)

    Co-Authored-By: Claude <noreply@anthropic.com>