### PR TITLE
FT-64: Link dish to encyclopedia from review page

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -127,6 +127,7 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/5.2/howto/static-files/
 
 STATIC_URL = 'static/'
+STATICFILES_DIRS = [BASE_DIR / 'static']
 
 # Media files
 MEDIA_ROOT = BASE_DIR / 'media'

--- a/content/models/encyclopedia.py
+++ b/content/models/encyclopedia.py
@@ -85,6 +85,22 @@ class Encyclopedia(models.Model):
 
         return ancestors
 
+    def get_hierarchy_breadcrumb(self, separator=' > '):
+        """
+        Get the hierarchy breadcrumb string for this entry.
+        Returns a string like "Asian > Thai > Pad Thai" where the ancestors
+        are listed from root to immediate parent (not including self).
+
+        Args:
+            separator: String to use between hierarchy levels (default: ' > ')
+
+        Returns:
+            String representation of the hierarchy path, empty string if no ancestors
+        """
+        ancestors = self.get_ancestors()
+        ancestors.reverse()  # Reverse to get root -> parent order
+        return separator.join([ancestor.name for ancestor in ancestors])
+
     def get_descendants(self):
         """
         Get all descendants of this entry recursively.

--- a/content/urls.py
+++ b/content/urls.py
@@ -13,4 +13,7 @@ urlpatterns = [
     path('reviews/<int:pk>/', views.ReviewDetailView.as_view(), name='review_detail'),
     path('recipes/', views.RecipeListView.as_view(), name='recipe_list'),
     path('recipes/<slug:slug>/', views.RecipeDetailView.as_view(), name='recipe_detail'),
+    # API endpoints
+    path('api/encyclopedia/search/', views.EncyclopediaSearchApiView.as_view(), name='api_encyclopedia_search'),
+    path('api/dishes/<int:dish_id>/link/', views.DishLinkApiView.as_view(), name='api_dish_link'),
 ]

--- a/content/views/__init__.py
+++ b/content/views/__init__.py
@@ -2,6 +2,8 @@ from .home import HomeView
 from .encyclopedia_list import EncyclopediaListView
 from .encyclopedia_detail import EncyclopediaDetailView
 from .encyclopedia_search import EncyclopediaSearchView
+from .encyclopedia_search_api import EncyclopediaSearchApiView
+from .dish_link_api import DishLinkApiView
 from .review_list import ReviewListView
 from .review_detail import ReviewDetailView
 from .recipe_list import RecipeListView
@@ -13,6 +15,8 @@ __all__ = [
     'EncyclopediaListView',
     'EncyclopediaDetailView',
     'EncyclopediaSearchView',
+    'EncyclopediaSearchApiView',
+    'DishLinkApiView',
     'ReviewListView',
     'ReviewDetailView',
     'RecipeListView',

--- a/content/views/dish_link_api.py
+++ b/content/views/dish_link_api.py
@@ -1,0 +1,75 @@
+from django.http import JsonResponse
+from django.views import View
+from django.utils.decorators import method_decorator
+from django.contrib.auth.decorators import login_required
+from django.shortcuts import get_object_or_404
+from content.models import ReviewDish, Encyclopedia
+import json
+
+
+@method_decorator(login_required, name='dispatch')
+class DishLinkApiView(View):
+    """
+    API endpoint for linking a ReviewDish to an Encyclopedia entry.
+    Requires authentication.
+    """
+
+    def post(self, request, dish_id, *args, **kwargs):
+        """
+        Link a dish to an encyclopedia entry.
+        POST body: {"encyclopedia_id": <id>}
+        """
+        try:
+            # Parse request body
+            data = json.loads(request.body)
+            encyclopedia_id = data.get('encyclopedia_id')
+
+            if not encyclopedia_id:
+                return JsonResponse({'error': 'encyclopedia_id is required'}, status=400)
+
+            # Get the dish and encyclopedia entry
+            dish = get_object_or_404(ReviewDish, id=dish_id)
+            encyclopedia_entry = get_object_or_404(Encyclopedia, id=encyclopedia_id)
+
+            # Update the link
+            dish.encyclopedia_entry = encyclopedia_entry
+            dish.save()
+
+            # Return updated dish info
+            return JsonResponse({
+                'success': True,
+                'dish': {
+                    'id': dish.id,
+                    'encyclopedia_entry': {
+                        'id': encyclopedia_entry.id,
+                        'name': encyclopedia_entry.name,
+                        'slug': encyclopedia_entry.slug,
+                        'hierarchy': encyclopedia_entry.get_hierarchy_breadcrumb(),
+                    }
+                }
+            })
+
+        except json.JSONDecodeError:
+            return JsonResponse({'error': 'Invalid JSON'}, status=400)
+        except Exception as e:
+            return JsonResponse({'error': str(e)}, status=500)
+
+    def delete(self, request, dish_id, *args, **kwargs):
+        """
+        Unlink a dish from its encyclopedia entry.
+        """
+        try:
+            dish = get_object_or_404(ReviewDish, id=dish_id)
+            dish.encyclopedia_entry = None
+            dish.save()
+
+            return JsonResponse({
+                'success': True,
+                'dish': {
+                    'id': dish.id,
+                    'encyclopedia_entry': None
+                }
+            })
+
+        except Exception as e:
+            return JsonResponse({'error': str(e)}, status=500)

--- a/content/views/encyclopedia_search_api.py
+++ b/content/views/encyclopedia_search_api.py
@@ -1,0 +1,62 @@
+from django.http import JsonResponse
+from django.views import View
+from django.contrib.postgres.search import SearchQuery, SearchRank
+from django.db.models import F, Q
+from content.models import Encyclopedia
+
+
+class EncyclopediaSearchApiView(View):
+    """
+    API endpoint for searching encyclopedia entries.
+    Returns JSON with search results including hierarchy breadcrumbs.
+    Supports partial matching for better user experience.
+    """
+
+    def get(self, request, *args, **kwargs):
+        """
+        Search encyclopedia entries and return JSON response.
+        Query parameter: q (search query)
+
+        Uses a multi-strategy approach:
+        1. Full-text search with prefix matching (e.g., "chee:*" matches "cheese")
+        2. Fallback to case-insensitive ILIKE for partial matches
+        """
+        query = request.GET.get('q', '').strip()
+
+        if not query:
+            return JsonResponse({'results': []})
+
+        # Strategy 1: Try full-text search with prefix matching
+        # Append :* to enable prefix matching (e.g., "che:*" matches "cheese")
+        prefix_query = query + ':*'
+        search_query = SearchQuery(prefix_query, search_type='raw')
+
+        entries = Encyclopedia.objects.annotate(
+            rank=SearchRank(F('search_vector'), search_query)
+        ).filter(
+            search_vector=search_query
+        ).select_related('parent')
+
+        # Strategy 2: If no results, fallback to ILIKE partial matching
+        if not entries.exists():
+            entries = Encyclopedia.objects.filter(
+                Q(name__icontains=query) |
+                Q(description__icontains=query)
+            ).select_related('parent')
+
+        # Limit to top 20 results and order by relevance
+        entries = entries[:20]
+
+        # Build results with hierarchy
+        results = []
+        for entry in entries:
+            results.append({
+                'id': entry.id,
+                'name': entry.name,
+                'slug': entry.slug,
+                'hierarchy': entry.get_hierarchy_breadcrumb(),
+                'cuisine_type': entry.cuisine_type or '',
+                'dish_category': entry.dish_category or '',
+            })
+
+        return JsonResponse({'results': results})

--- a/static/js/encyclopedia_link.js
+++ b/static/js/encyclopedia_link.js
@@ -1,0 +1,293 @@
+// Encyclopedia Link Modal JavaScript
+// Handles linking/unlinking dishes to encyclopedia entries
+
+document.addEventListener('DOMContentLoaded', function() {
+    const modalElement = document.getElementById('encyclopediaLinkModal');
+    if (!modalElement) return; // Modal not present (user not authenticated)
+
+    const modal = new bootstrap.Modal(modalElement);
+    const searchInput = document.getElementById('encyclopediaSearch');
+    const searchResults = document.getElementById('searchResults');
+    const searchStatus = document.getElementById('searchStatus');
+    const currentDishNameEl = document.getElementById('currentDishName');
+    let currentDishId = null;
+    let currentDishName = null;
+    let searchTimeout = null;
+    let selectedIndex = -1;
+
+    // Open modal when "Link to Encyclopedia" button is clicked
+    function attachLinkHandlers() {
+        document.querySelectorAll('.link-dish-btn').forEach(btn => {
+            btn.addEventListener('click', function() {
+                currentDishId = this.dataset.dishId;
+                currentDishName = this.dataset.dishName;
+                currentDishNameEl.textContent = currentDishName;
+                searchInput.value = '';
+                selectedIndex = -1;
+                modal.show();
+                // Focus on search input
+                setTimeout(() => searchInput.focus(), 100);
+            });
+        });
+    }
+    attachLinkHandlers();
+
+    // Handle unlink button clicks
+    function attachUnlinkHandlers() {
+        document.querySelectorAll('.unlink-dish-btn').forEach(btn => {
+            btn.addEventListener('click', function() {
+                const dishId = this.dataset.dishId;
+                if (confirm('Are you sure you want to unlink this encyclopedia entry?')) {
+                    unlinkDishFromEncyclopedia(dishId);
+                }
+            });
+        });
+    }
+    attachUnlinkHandlers();
+
+    // Reset modal on close
+    modalElement.addEventListener('hidden.bs.modal', function() {
+        searchInput.value = '';
+        searchResults.innerHTML = '';
+        searchStatus.style.display = 'none';
+        currentDishId = null;
+        currentDishName = null;
+        selectedIndex = -1;
+    });
+
+    // Debounced search
+    searchInput.addEventListener('input', function() {
+        clearTimeout(searchTimeout);
+        const query = this.value.trim();
+
+        if (query.length < 2) {
+            searchResults.innerHTML = '';
+            searchStatus.style.display = 'block';
+            searchStatus.innerHTML = '<em>Type at least 2 characters to search</em>';
+            return;
+        }
+
+        searchStatus.style.display = 'block';
+        searchStatus.innerHTML = '<div class="spinner-border spinner-border-sm" role="status"><span class="visually-hidden">Loading...</span></div> Searching...';
+
+        searchTimeout = setTimeout(() => performSearch(query), 300);
+    });
+
+    // Keyboard navigation
+    searchInput.addEventListener('keydown', function(e) {
+        const items = searchResults.querySelectorAll('.list-group-item');
+
+        if (e.key === 'Escape') {
+            modal.hide();
+            return;
+        }
+
+        if (items.length === 0) return;
+
+        if (e.key === 'ArrowDown') {
+            e.preventDefault();
+            selectedIndex = Math.min(selectedIndex + 1, items.length - 1);
+            updateSelection(items);
+        } else if (e.key === 'ArrowUp') {
+            e.preventDefault();
+            selectedIndex = Math.max(selectedIndex - 1, -1);
+            updateSelection(items);
+        } else if (e.key === 'Enter' && selectedIndex >= 0) {
+            e.preventDefault();
+            items[selectedIndex].click();
+        }
+    });
+
+    function updateSelection(items) {
+        items.forEach((item, index) => {
+            if (index === selectedIndex) {
+                item.classList.add('active');
+                item.scrollIntoView({ block: 'nearest' });
+            } else {
+                item.classList.remove('active');
+            }
+        });
+    }
+
+    function performSearch(query) {
+        const apiUrl = document.getElementById('encyclopediaLinkModal').dataset.searchUrl;
+
+        fetch(`${apiUrl}?q=${encodeURIComponent(query)}`)
+            .then(response => response.json())
+            .then(data => {
+                searchStatus.style.display = 'none';
+
+                if (data.results.length === 0) {
+                    searchResults.innerHTML = '';
+                    searchStatus.style.display = 'block';
+                    searchStatus.innerHTML = '<em>No results found</em>';
+                    return;
+                }
+
+                selectedIndex = -1;
+                searchResults.innerHTML = data.results.map(entry => `
+                    <button type="button" class="list-group-item list-group-item-action encyclopedia-result"
+                            data-entry-id="${entry.id}"
+                            data-entry-name="${entry.name}"
+                            data-entry-slug="${entry.slug}">
+                        <div class="d-flex w-100 justify-content-between">
+                            <h6 class="mb-1">${entry.name}</h6>
+                            ${entry.cuisine_type ? `<small class="badge bg-info">${entry.cuisine_type}</small>` : ''}
+                        </div>
+                        ${entry.hierarchy ? `<small class="text-muted"><i class="bi bi-arrow-right-short"></i> ${entry.hierarchy}</small>` : ''}
+                        ${entry.dish_category ? `<small class="badge bg-secondary ms-2">${entry.dish_category}</small>` : ''}
+                    </button>
+                `).join('');
+
+                // Add click handlers to results
+                document.querySelectorAll('.encyclopedia-result').forEach(item => {
+                    item.addEventListener('click', function() {
+                        linkDishToEncyclopedia(
+                            currentDishId,
+                            this.dataset.entryId,
+                            this.dataset.entryName,
+                            this.dataset.entrySlug
+                        );
+                    });
+                });
+            })
+            .catch(error => {
+                console.error('Search error:', error);
+                searchStatus.style.display = 'block';
+                searchStatus.innerHTML = '<em class="text-danger">Error performing search</em>';
+            });
+    }
+
+    function linkDishToEncyclopedia(dishId, encyclopediaId, encyclopediaName, encyclopediaSlug) {
+        // Get CSRF token
+        const csrfToken = document.querySelector('[name=csrfmiddlewaretoken]')?.value ||
+                         getCookie('csrftoken');
+
+        fetch(`/api/dishes/${dishId}/link/`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'X-CSRFToken': csrfToken
+            },
+            body: JSON.stringify({
+                encyclopedia_id: encyclopediaId
+            })
+        })
+        .then(response => response.json())
+        .then(data => {
+            if (data.success) {
+                // Update the UI
+                const dishBtn = document.querySelector(`.link-dish-btn[data-dish-id="${dishId}"]`);
+                if (dishBtn) {
+                    const dishName = dishBtn.dataset.dishName;
+                    const container = dishBtn.closest('.mb-2');
+
+                    // Replace the link button with the encyclopedia link display
+                    container.innerHTML = `
+                        <small class="text-muted">
+                            <i class="bi bi-book"></i> Linked to:
+                            <a href="/encyclopedia/${encyclopediaSlug}/" class="text-decoration-none">
+                                <strong>${encyclopediaName}</strong>
+                            </a>
+                            <button class="btn btn-link btn-sm p-0 ms-1 text-danger unlink-dish-btn"
+                                    data-dish-id="${dishId}"
+                                    style="font-size: 0.75rem; text-decoration: none;"
+                                    title="Unlink encyclopedia entry">
+                                <i class="bi bi-x-circle"></i>
+                            </button>
+                        </small>
+                    `;
+
+                    // Re-attach unlink handlers
+                    attachUnlinkHandlers();
+                }
+                modal.hide();
+
+                // Show success message
+                showToast('Success', `Dish linked to ${encyclopediaName}`, 'success');
+            } else {
+                showToast('Error', data.error || 'Failed to link dish', 'danger');
+            }
+        })
+        .catch(error => {
+            console.error('Link error:', error);
+            showToast('Error', 'Failed to link dish', 'danger');
+        });
+    }
+
+    function unlinkDishFromEncyclopedia(dishId) {
+        // Get CSRF token
+        const csrfToken = document.querySelector('[name=csrfmiddlewaretoken]')?.value ||
+                         getCookie('csrftoken');
+
+        fetch(`/api/dishes/${dishId}/link/`, {
+            method: 'DELETE',
+            headers: {
+                'X-CSRFToken': csrfToken
+            }
+        })
+        .then(response => response.json())
+        .then(data => {
+            if (data.success) {
+                // Find the unlink button and get the dish name from the h5
+                const unlinkBtn = document.querySelector(`.unlink-dish-btn[data-dish-id="${dishId}"]`);
+                if (unlinkBtn) {
+                    const listItem = unlinkBtn.closest('.list-group-item');
+                    const h5 = listItem.querySelector('h5');
+                    const dishName = h5.textContent.trim();
+                    const container = unlinkBtn.closest('.mb-2');
+
+                    // Replace the encyclopedia link with the "Link to Encyclopedia" button
+                    container.innerHTML = `
+                        <button class="badge bg-secondary border-0 link-dish-btn"
+                                data-dish-id="${dishId}"
+                                data-dish-name="${dishName}"
+                                style="cursor: pointer;">
+                            <i class="bi bi-link-45deg"></i> Link to Encyclopedia
+                        </button>
+                    `;
+
+                    // Re-attach link handlers
+                    attachLinkHandlers();
+                }
+
+                // Show success message
+                showToast('Success', 'Encyclopedia entry unlinked', 'success');
+            } else {
+                showToast('Error', data.error || 'Failed to unlink dish', 'danger');
+            }
+        })
+        .catch(error => {
+            console.error('Unlink error:', error);
+            showToast('Error', 'Failed to unlink dish', 'danger');
+        });
+    }
+
+    function getCookie(name) {
+        let cookieValue = null;
+        if (document.cookie && document.cookie !== '') {
+            const cookies = document.cookie.split(';');
+            for (let i = 0; i < cookies.length; i++) {
+                const cookie = cookies[i].trim();
+                if (cookie.substring(0, name.length + 1) === (name + '=')) {
+                    cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
+                    break;
+                }
+            }
+        }
+        return cookieValue;
+    }
+
+    function showToast(title, message, type) {
+        // Simple toast notification
+        const alertDiv = document.createElement('div');
+        alertDiv.className = `alert alert-${type} alert-dismissible fade show position-fixed top-0 start-50 translate-middle-x mt-3`;
+        alertDiv.style.zIndex = '9999';
+        alertDiv.innerHTML = `
+            <strong>${title}:</strong> ${message}
+            <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
+        `;
+        document.body.appendChild(alertDiv);
+        setTimeout(() => alertDiv.remove(), 5000);
+    }
+});

--- a/templates/components/encyclopedia_link_modal.html
+++ b/templates/components/encyclopedia_link_modal.html
@@ -1,0 +1,29 @@
+<!-- Encyclopedia Link Modal -->
+{% if user.is_authenticated %}
+<div class="modal fade" id="encyclopediaLinkModal" tabindex="-1" aria-labelledby="encyclopediaLinkModalLabel" aria-hidden="true" data-search-url="{% url 'content:api_encyclopedia_search' %}">
+    <div class="modal-dialog modal-lg">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="encyclopediaLinkModalLabel">Link Dish to Encyclopedia Entry</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <div class="mb-3">
+                    <label for="encyclopediaSearch" class="form-label">Search for dish: <strong id="currentDishName"></strong></label>
+                    <input type="text" class="form-control" id="encyclopediaSearch" placeholder="Start typing to search...">
+                    <div class="form-text">Search by name or description</div>
+                </div>
+                <div id="searchResults" class="list-group" style="max-height: 400px; overflow-y: auto;">
+                    <!-- Results will be populated here -->
+                </div>
+                <div id="searchStatus" class="text-muted text-center py-3" style="display: none;">
+                    <!-- Status messages -->
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+            </div>
+        </div>
+    </div>
+</div>
+{% endif %}

--- a/templates/review/detail.html
+++ b/templates/review/detail.html
@@ -1,6 +1,7 @@
 {% extends 'base.html' %}
 {% load review_tags %}
 {% load admin_tags %}
+{% load static %}
 
 {% block title %}{{ review.restaurant_name }} - Reviews - Food Table{% endblock %}
 
@@ -88,17 +89,45 @@
                         <div class="d-flex justify-content-between align-items-start">
                             <div class="flex-grow-1">
                                 <h5 class="mb-1">
-                                    {% if dish.encyclopedia_entry %}
-                                    <a href="{% url 'content:encyclopedia_detail' dish.encyclopedia_entry.slug %}">
-                                        {{ dish.encyclopedia_entry.name }}
-                                    </a>
-                                    {% elif dish.dish_name %}
+                                    {% if dish.dish_name %}
                                     {{ dish.dish_name }}
-                                    <span class="badge bg-secondary ms-2">Not Linked</span>
+                                    {% elif dish.encyclopedia_entry %}
+                                    {{ dish.encyclopedia_entry.name }}
                                     {% else %}
                                     <span class="text-muted">Unlinked Dish</span>
                                     {% endif %}
                                 </h5>
+                                {% if dish.encyclopedia_entry %}
+                                <div class="mb-2">
+                                    <small class="text-muted">
+                                        <i class="bi bi-book"></i> Linked to:
+                                        <a href="{% url 'content:encyclopedia_detail' dish.encyclopedia_entry.slug %}" class="text-decoration-none">
+                                            <strong>{{ dish.encyclopedia_entry.name }}</strong>
+                                        </a>
+                                        {% if user.is_authenticated %}
+                                        <button class="btn btn-link btn-sm p-0 ms-1 text-danger unlink-dish-btn"
+                                                data-dish-id="{{ dish.id }}"
+                                                style="font-size: 0.75rem; text-decoration: none;"
+                                                title="Unlink encyclopedia entry">
+                                            <i class="bi bi-x-circle"></i>
+                                        </button>
+                                        {% endif %}
+                                    </small>
+                                </div>
+                                {% elif dish.dish_name %}
+                                <div class="mb-2">
+                                    {% if user.is_authenticated %}
+                                    <button class="badge bg-secondary border-0 link-dish-btn"
+                                            data-dish-id="{{ dish.id }}"
+                                            data-dish-name="{{ dish.dish_name }}"
+                                            style="cursor: pointer;">
+                                        <i class="bi bi-link-45deg"></i> Link to Encyclopedia
+                                    </button>
+                                    {% else %}
+                                    <span class="badge bg-secondary">Not Linked</span>
+                                    {% endif %}
+                                </div>
+                                {% endif %}
                                 {% if dish.dish_rating %}
                                 <div class="mb-2">
                                     {{ dish.dish_rating|rating_to_stars }}
@@ -190,4 +219,13 @@
         <a href="{% url 'content:review_list' %}" class="btn btn-secondary">Back to Reviews</a>
     </div>
 </div>
+
+<!-- Include Encyclopedia Link Modal -->
+{% include 'components/encyclopedia_link_modal.html' %}
+{% endblock %}
+
+{% block extra_js %}
+{% if user.is_authenticated %}
+<script src="{% static 'js/encyclopedia_link.js' %}"></script>
+{% endif %}
 {% endblock %}


### PR DESCRIPTION
Add modal-based linking interface for dishes on review detail page. Use prefix search for better UX when users type partial encyclopedia names (e.g., "chee" matches "cheese").

🤖 Generated with [Claude Code](https://claude.com/claude-code)