### PR TITLE
FT-65: Add in-modal encyclopedia entry creation

### DIFF
--- a/content/urls.py
+++ b/content/urls.py
@@ -15,5 +15,6 @@ urlpatterns = [
     path('recipes/<slug:slug>/', views.RecipeDetailView.as_view(), name='recipe_detail'),
     # API endpoints
     path('api/encyclopedia/search/', views.EncyclopediaSearchApiView.as_view(), name='api_encyclopedia_search'),
+    path('api/encyclopedia/create/', views.EncyclopediaCreateApiView.as_view(), name='api_encyclopedia_create'),
     path('api/dishes/<int:dish_id>/link/', views.DishLinkApiView.as_view(), name='api_dish_link'),
 ]

--- a/content/views/__init__.py
+++ b/content/views/__init__.py
@@ -3,6 +3,7 @@ from .encyclopedia_list import EncyclopediaListView
 from .encyclopedia_detail import EncyclopediaDetailView
 from .encyclopedia_search import EncyclopediaSearchView
 from .encyclopedia_search_api import EncyclopediaSearchApiView
+from .encyclopedia_create_api import EncyclopediaCreateApiView
 from .dish_link_api import DishLinkApiView
 from .review_list import ReviewListView
 from .review_detail import ReviewDetailView
@@ -16,6 +17,7 @@ __all__ = [
     'EncyclopediaDetailView',
     'EncyclopediaSearchView',
     'EncyclopediaSearchApiView',
+    'EncyclopediaCreateApiView',
     'DishLinkApiView',
     'ReviewListView',
     'ReviewDetailView',

--- a/content/views/encyclopedia_create_api.py
+++ b/content/views/encyclopedia_create_api.py
@@ -1,0 +1,124 @@
+from django.http import JsonResponse
+from django.views import View
+from django.utils.decorators import method_decorator
+from django.contrib.auth.decorators import login_required
+from django.shortcuts import get_object_or_404
+from django.utils.text import slugify
+from django.core.exceptions import ValidationError
+from django.db import IntegrityError
+from content.models import ReviewDish, Encyclopedia
+import json
+
+
+@method_decorator(login_required, name='dispatch')
+class EncyclopediaCreateApiView(View):
+    """
+    API endpoint for creating a new Encyclopedia entry and linking it to a dish.
+    Requires authentication.
+    """
+
+    def post(self, request, *args, **kwargs):
+        """
+        Create a new encyclopedia entry and link it to a dish.
+        POST body: {
+            "name": str (required),
+            "description": str (required),
+            "cuisine_type": str (optional),
+            "dish_category": str (optional),
+            "parent_id": int (optional),
+            "dish_id": int (required)
+        }
+        """
+        try:
+            # Parse request body
+            data = json.loads(request.body)
+
+            # Extract required fields
+            name = data.get('name', '').strip()
+            description = data.get('description', '').strip()
+            dish_id = data.get('dish_id')
+
+            # Validate required fields
+            if not name:
+                return JsonResponse({'error': 'Name is required'}, status=400)
+            if not description:
+                return JsonResponse({'error': 'Description is required'}, status=400)
+            if not dish_id:
+                return JsonResponse({'error': 'Dish ID is required'}, status=400)
+
+            # Get the dish
+            dish = get_object_or_404(ReviewDish, id=dish_id)
+
+            # Extract optional fields
+            cuisine_type = data.get('cuisine_type', '').strip() or None
+            dish_category = data.get('dish_category', '').strip() or None
+            region = data.get('region', '').strip() or None
+            cultural_significance = data.get('cultural_significance', '').strip()
+            popular_examples = data.get('popular_examples', '').strip()
+            history = data.get('history', '').strip()
+            parent_id = data.get('parent_id')
+
+            # Get parent if provided
+            parent = None
+            if parent_id:
+                try:
+                    parent = Encyclopedia.objects.get(id=parent_id)
+                except Encyclopedia.DoesNotExist:
+                    return JsonResponse({'error': 'Invalid parent entry'}, status=400)
+
+            # Generate slug
+            base_slug = slugify(name)
+            slug = base_slug
+            counter = 1
+
+            # Handle duplicate slugs by appending a number
+            while Encyclopedia.objects.filter(slug=slug).exists():
+                slug = f"{base_slug}-{counter}"
+                counter += 1
+
+            # Create the encyclopedia entry
+            encyclopedia_entry = Encyclopedia(
+                name=name,
+                slug=slug,
+                description=description,
+                cuisine_type=cuisine_type,
+                dish_category=dish_category,
+                region=region,
+                cultural_significance=cultural_significance,
+                popular_examples=popular_examples,
+                history=history,
+                parent=parent,
+                created_by=request.user
+            )
+
+            # Validate and save
+            try:
+                encyclopedia_entry.full_clean()
+                encyclopedia_entry.save()
+            except ValidationError as e:
+                return JsonResponse({'error': str(e)}, status=400)
+
+            # Link the dish to the new encyclopedia entry
+            dish.encyclopedia_entry = encyclopedia_entry
+            dish.save()
+
+            # Return success response
+            return JsonResponse({
+                'success': True,
+                'encyclopedia': {
+                    'id': encyclopedia_entry.id,
+                    'name': encyclopedia_entry.name,
+                    'slug': encyclopedia_entry.slug,
+                    'hierarchy': encyclopedia_entry.get_hierarchy_breadcrumb(),
+                },
+                'dish': {
+                    'id': dish.id,
+                }
+            })
+
+        except json.JSONDecodeError:
+            return JsonResponse({'error': 'Invalid JSON'}, status=400)
+        except IntegrityError as e:
+            return JsonResponse({'error': f'Database error: {str(e)}'}, status=500)
+        except Exception as e:
+            return JsonResponse({'error': str(e)}, status=500)

--- a/templates/components/encyclopedia_link_modal.html
+++ b/templates/components/encyclopedia_link_modal.html
@@ -8,20 +8,91 @@
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
             </div>
             <div class="modal-body">
-                <div class="mb-3">
-                    <label for="encyclopediaSearch" class="form-label">Search for dish: <strong id="currentDishName"></strong></label>
-                    <input type="text" class="form-control" id="encyclopediaSearch" placeholder="Start typing to search...">
-                    <div class="form-text">Search by name or description</div>
+                <!-- Search Section -->
+                <div id="searchSection">
+                    <div class="mb-3">
+                        <label for="encyclopediaSearch" class="form-label">Search for dish: <strong id="currentDishName"></strong></label>
+                        <input type="text" class="form-control" id="encyclopediaSearch" placeholder="Start typing to search...">
+                        <div class="form-text">Search by name or description</div>
+                    </div>
+                    <div id="searchResults" class="list-group" style="max-height: 400px; overflow-y: auto;">
+                        <!-- Results will be populated here -->
+                    </div>
+                    <div id="searchStatus" class="text-muted text-center py-3" style="display: none;">
+                        <!-- Status messages -->
+                    </div>
                 </div>
-                <div id="searchResults" class="list-group" style="max-height: 400px; overflow-y: auto;">
-                    <!-- Results will be populated here -->
-                </div>
-                <div id="searchStatus" class="text-muted text-center py-3" style="display: none;">
-                    <!-- Status messages -->
+
+                <!-- Create New Entry Form -->
+                <div id="createEntrySection" style="display: none;">
+                    <div class="mb-3">
+                        <button type="button" class="btn btn-link p-0 mb-3" id="backToSearch">
+                            <i class="bi bi-arrow-left"></i> Back to search
+                        </button>
+                    </div>
+                    <h6 class="mb-3">Create New Encyclopedia Entry</h6>
+                    <form id="createEntryForm">
+                        <div class="mb-3">
+                            <label for="entryName" class="form-label">Name <span class="text-danger">*</span></label>
+                            <input type="text" class="form-control" id="entryName" required>
+                        </div>
+                        <div class="mb-3">
+                            <label for="entryDescription" class="form-label">Description <span class="text-danger">*</span></label>
+                            <textarea class="form-control" id="entryDescription" rows="3" required></textarea>
+                        </div>
+                        <div class="mb-3">
+                            <label for="entryCuisineType" class="form-label">Cuisine Type</label>
+                            <input type="text" class="form-control" id="entryCuisineType" placeholder="e.g., Thai, Italian, Chinese">
+                        </div>
+                        <div class="mb-3">
+                            <label for="entryDishCategory" class="form-label">Dish Category</label>
+                            <input type="text" class="form-control" id="entryDishCategory" placeholder="e.g., Noodles, Soup, Dessert">
+                        </div>
+                        <div class="mb-3">
+                            <label for="entryRegion" class="form-label">Region</label>
+                            <input type="text" class="form-control" id="entryRegion" placeholder="e.g., Northern Thailand, Southern Italy">
+                        </div>
+                        <div class="mb-3">
+                            <label for="entryCulturalSignificance" class="form-label">Cultural Significance</label>
+                            <textarea class="form-control" id="entryCulturalSignificance" rows="3" placeholder="Describe the cultural importance or traditions..."></textarea>
+                        </div>
+                        <div class="mb-3">
+                            <label for="entryPopularExamples" class="form-label">Popular Examples</label>
+                            <textarea class="form-control" id="entryPopularExamples" rows="2" placeholder="List well-known examples or variations..."></textarea>
+                        </div>
+                        <div class="mb-3">
+                            <label for="entryHistory" class="form-label">History</label>
+                            <textarea class="form-control" id="entryHistory" rows="3" placeholder="Describe the historical background..."></textarea>
+                        </div>
+                        <div class="mb-3">
+                            <label for="entryParentSearch" class="form-label">Parent Entry (Optional)</label>
+                            <input type="text" class="form-control" id="entryParentSearch" placeholder="Search for parent entry...">
+                            <div class="form-text">Link this entry under a broader category</div>
+                            <div id="parentSearchResults" class="list-group mt-2" style="max-height: 200px; overflow-y: auto; display: none;">
+                                <!-- Parent search results will be populated here -->
+                            </div>
+                            <div id="selectedParent" class="alert alert-info mt-2" style="display: none;">
+                                <strong>Selected:</strong> <span id="selectedParentName"></span>
+                                <button type="button" class="btn-close float-end" id="clearParent" aria-label="Clear"></button>
+                            </div>
+                        </div>
+                        <div id="createFormError" class="alert alert-danger" style="display: none;"></div>
+                    </form>
                 </div>
             </div>
             <div class="modal-footer">
-                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                <div id="searchFooter" class="w-100">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                    <button type="button" class="btn btn-primary" id="showCreateFormBtn" style="display: none;">
+                        <i class="bi bi-plus-circle"></i> Create New Entry
+                    </button>
+                </div>
+                <div id="createFooter" class="w-100" style="display: none;">
+                    <button type="button" class="btn btn-secondary" id="cancelCreate">Cancel</button>
+                    <button type="button" class="btn btn-primary" id="saveAndLinkBtn">
+                        <i class="bi bi-check-circle"></i> Save & Link
+                    </button>
+                </div>
             </div>
         </div>
     </div>


### PR DESCRIPTION
    Enable creation of encyclopedia entries directly from the link
    modal. Pre-populate entry name with dish name to streamline
    workflow and reduce friction.

    Include parent search autocomplete to maintain hierarchical
    structure during creation.

    🤖 Generated with [Claude Code](https://claude.com/claude-code)

    Co-Authored-By: Claude <noreply@anthropic.com>