### PR TITLE
FT-66: Restrict dish linking to admin users

### DIFF
--- a/content/views/dish_link_api.py
+++ b/content/views/dish_link_api.py
@@ -1,17 +1,22 @@
 from django.http import JsonResponse
 from django.views import View
 from django.utils.decorators import method_decorator
-from django.contrib.auth.decorators import login_required
+from django.contrib.auth.decorators import login_required, user_passes_test
 from django.shortcuts import get_object_or_404
 from content.models import ReviewDish, Encyclopedia
 import json
 
 
-@method_decorator(login_required, name='dispatch')
+def is_staff_user(user):
+    """Check if user is staff."""
+    return user.is_staff
+
+
+@method_decorator([login_required, user_passes_test(is_staff_user)], name='dispatch')
 class DishLinkApiView(View):
     """
     API endpoint for linking a ReviewDish to an Encyclopedia entry.
-    Requires authentication.
+    Requires authentication and staff permissions.
     """
 
     def post(self, request, dish_id, *args, **kwargs):

--- a/content/views/encyclopedia_create_api.py
+++ b/content/views/encyclopedia_create_api.py
@@ -1,7 +1,7 @@
 from django.http import JsonResponse
 from django.views import View
 from django.utils.decorators import method_decorator
-from django.contrib.auth.decorators import login_required
+from django.contrib.auth.decorators import login_required, user_passes_test
 from django.shortcuts import get_object_or_404
 from django.utils.text import slugify
 from django.core.exceptions import ValidationError
@@ -10,11 +10,16 @@ from content.models import ReviewDish, Encyclopedia
 import json
 
 
-@method_decorator(login_required, name='dispatch')
+def is_staff_user(user):
+    """Check if user is staff."""
+    return user.is_staff
+
+
+@method_decorator([login_required, user_passes_test(is_staff_user)], name='dispatch')
 class EncyclopediaCreateApiView(View):
     """
     API endpoint for creating a new Encyclopedia entry and linking it to a dish.
-    Requires authentication.
+    Requires authentication and staff permissions.
     """
 
     def post(self, request, *args, **kwargs):

--- a/templates/components/encyclopedia_link_modal.html
+++ b/templates/components/encyclopedia_link_modal.html
@@ -1,5 +1,5 @@
 <!-- Encyclopedia Link Modal -->
-{% if user.is_authenticated %}
+{% if user.is_staff %}
 <div class="modal fade" id="encyclopediaLinkModal" tabindex="-1" aria-labelledby="encyclopediaLinkModalLabel" aria-hidden="true" data-search-url="{% url 'content:api_encyclopedia_search' %}">
     <div class="modal-dialog modal-lg">
         <div class="modal-content">

--- a/templates/review/detail.html
+++ b/templates/review/detail.html
@@ -104,7 +104,7 @@
                                         <a href="{% url 'content:encyclopedia_detail' dish.encyclopedia_entry.slug %}" class="text-decoration-none">
                                             <strong>{{ dish.encyclopedia_entry.name }}</strong>
                                         </a>
-                                        {% if user.is_authenticated %}
+                                        {% if user.is_staff %}
                                         <button class="btn btn-link btn-sm p-0 ms-1 text-danger unlink-dish-btn"
                                                 data-dish-id="{{ dish.id }}"
                                                 style="font-size: 0.75rem; text-decoration: none;"
@@ -116,7 +116,7 @@
                                 </div>
                                 {% elif dish.dish_name %}
                                 <div class="mb-2">
-                                    {% if user.is_authenticated %}
+                                    {% if user.is_staff %}
                                     <button class="badge bg-secondary border-0 link-dish-btn"
                                             data-dish-id="{{ dish.id }}"
                                             data-dish-name="{{ dish.dish_name }}"
@@ -225,7 +225,7 @@
 {% endblock %}
 
 {% block extra_js %}
-{% if user.is_authenticated %}
+{% if user.is_staff %}
 <script src="{% static 'js/encyclopedia_link.js' %}"></script>
 {% endif %}
 {% endblock %}


### PR DESCRIPTION
    Require staff permissions for encyclopedia linking
    features to prevent unauthorized data modification.

    🤖 Generated with [Claude Code](https://claude.com/claude-code)

    Co-Authored-By: Claude <noreply@anthropic.com>