### PR TITLE
FT-74: Add photo upload to review dishes

### DIFF
--- a/content/admin/review.py
+++ b/content/admin/review.py
@@ -6,6 +6,14 @@ from content.models import Review, ReviewDish, ReviewTag, Image
 from .inlines import ImageInline
 
 
+class DishImageInline(GenericTabularInline):
+    """Inline for managing images attached to dishes"""
+    model = Image
+    extra = 1
+    fields = ['image', 'caption', 'alt_text', 'order']
+    ordering = ['order']
+
+
 class ReviewDishInline(admin.TabularInline):
     """Inline for managing dishes attached to reviews"""
     model = ReviewDish
@@ -73,3 +81,27 @@ class ReviewAdmin(admin.ModelAdmin):
         if not change:  # Only set on creation, not on update
             obj.created_by = request.user
         super().save_model(request, obj, form, change)
+
+
+@admin.register(ReviewDish)
+class ReviewDishAdmin(admin.ModelAdmin):
+    """Admin interface for ReviewDish model"""
+
+    list_display = ['dish_name', 'review', 'dish_rating', 'cost']
+    list_filter = ['dish_rating', 'review__visit_date']
+    search_fields = ['dish_name', 'notes', 'review__restaurant_name']
+    autocomplete_fields = ['encyclopedia_entry', 'review']
+
+    fieldsets = (
+        ('Dish Information', {
+            'fields': ('review', 'dish_name', 'encyclopedia_entry')
+        }),
+        ('Rating and Cost', {
+            'fields': ('dish_rating', 'cost')
+        }),
+        ('Notes', {
+            'fields': ('notes',)
+        }),
+    )
+
+    inlines = [DishImageInline]

--- a/content/urls.py
+++ b/content/urls.py
@@ -18,4 +18,5 @@ urlpatterns = [
     path('api/encyclopedia/suggest/', views.EncyclopediaSuggestApiView.as_view(), name='api_encyclopedia_suggest'),
     path('api/encyclopedia/create/', views.EncyclopediaCreateApiView.as_view(), name='api_encyclopedia_create'),
     path('api/dishes/<int:dish_id>/link/', views.DishLinkApiView.as_view(), name='api_dish_link'),
+    path('api/dishes/<int:dish_id>/upload-image/', views.DishImageUploadApiView.as_view(), name='api_dish_image_upload'),
 ]

--- a/content/views/__init__.py
+++ b/content/views/__init__.py
@@ -6,6 +6,7 @@ from .encyclopedia_search_api import EncyclopediaSearchApiView
 from .encyclopedia_suggest_api import EncyclopediaSuggestApiView
 from .encyclopedia_create_api import EncyclopediaCreateApiView
 from .dish_link_api import DishLinkApiView
+from .dish_image_api import DishImageUploadApiView
 from .review_list import ReviewListView
 from .review_detail import ReviewDetailView
 from .recipe_list import RecipeListView
@@ -21,6 +22,7 @@ __all__ = [
     'EncyclopediaSuggestApiView',
     'EncyclopediaCreateApiView',
     'DishLinkApiView',
+    'DishImageUploadApiView',
     'ReviewListView',
     'ReviewDetailView',
     'RecipeListView',

--- a/content/views/dish_image_api.py
+++ b/content/views/dish_image_api.py
@@ -1,0 +1,85 @@
+from django.http import JsonResponse
+from django.views import View
+from django.utils.decorators import method_decorator
+from django.contrib.auth.decorators import login_required, user_passes_test
+from django.shortcuts import get_object_or_404
+from django.contrib.contenttypes.models import ContentType
+from content.models import ReviewDish, Image
+
+
+def is_staff_user(user):
+    """Check if user is staff."""
+    return user.is_staff
+
+
+@method_decorator([login_required, user_passes_test(is_staff_user)], name='dispatch')
+class DishImageUploadApiView(View):
+    """
+    API endpoint for uploading images to a ReviewDish.
+    Requires authentication and staff permissions.
+    """
+
+    def post(self, request, dish_id, *args, **kwargs):
+        """
+        Upload an image to a dish.
+        POST body (multipart/form-data):
+            - image: image file (required)
+            - caption: optional caption
+            - alt_text: optional alt text
+            - order: optional order (defaults to 0)
+        """
+        try:
+            # Get the dish
+            dish = get_object_or_404(ReviewDish, id=dish_id)
+
+            # Get the uploaded file
+            image_file = request.FILES.get('image')
+            if not image_file:
+                return JsonResponse({'error': 'No image file provided'}, status=400)
+
+            # Validate file type
+            allowed_types = ['image/jpeg', 'image/png', 'image/gif', 'image/webp']
+            if image_file.content_type not in allowed_types:
+                return JsonResponse({
+                    'error': f'Invalid file type. Allowed types: JPEG, PNG, GIF, WebP'
+                }, status=400)
+
+            # Validate file size (10MB max)
+            max_size = 10 * 1024 * 1024  # 10MB in bytes
+            if image_file.size > max_size:
+                return JsonResponse({
+                    'error': f'File too large. Maximum size is 10MB'
+                }, status=400)
+
+            # Get optional fields
+            caption = request.POST.get('caption', '')
+            alt_text = request.POST.get('alt_text', '')
+            order = request.POST.get('order', 0)
+
+            # Create the Image instance
+            content_type = ContentType.objects.get_for_model(ReviewDish)
+            image = Image.objects.create(
+                image=image_file,
+                caption=caption,
+                alt_text=alt_text,
+                order=order,
+                content_type=content_type,
+                object_id=dish.id,
+                uploaded_by=request.user
+            )
+
+            # Return success response with image data
+            return JsonResponse({
+                'success': True,
+                'image': {
+                    'id': image.id,
+                    'url': image.image.url,
+                    'caption': image.caption,
+                    'alt_text': image.alt_text,
+                    'order': image.order,
+                    'uploaded_at': image.uploaded_at.isoformat(),
+                }
+            })
+
+        except Exception as e:
+            return JsonResponse({'error': str(e)}, status=500)

--- a/static/js/dish_image_upload.js
+++ b/static/js/dish_image_upload.js
@@ -1,0 +1,234 @@
+// Dish Image Upload JavaScript
+// Handles uploading images to review dishes
+
+document.addEventListener('DOMContentLoaded', function() {
+    const modalElement = document.getElementById('dishImageUploadModal');
+    if (!modalElement) return; // Modal not present (user not authenticated)
+
+    const modal = new bootstrap.Modal(modalElement);
+    const uploadForm = document.getElementById('dishImageUploadForm');
+    const fileInput = document.getElementById('dishImageFile');
+    const captionInput = document.getElementById('dishImageCaption');
+    const altTextInput = document.getElementById('dishImageAltText');
+    const imagePreviewContainer = document.getElementById('imagePreviewContainer');
+    const imagePreview = document.getElementById('imagePreview');
+    const uploadBtn = document.getElementById('uploadImageBtn');
+    const uploadBtnText = document.getElementById('uploadBtnText');
+    const uploadBtnSpinner = document.getElementById('uploadBtnSpinner');
+    const uploadBtnLoading = document.getElementById('uploadBtnLoading');
+    const uploadError = document.getElementById('uploadError');
+    const uploadSuccess = document.getElementById('uploadSuccess');
+
+    let currentDishId = null;
+
+    // Open modal when "Upload Photo" button is clicked
+    function attachUploadHandlers() {
+        document.querySelectorAll('.upload-dish-image-btn').forEach(btn => {
+            btn.addEventListener('click', function() {
+                currentDishId = this.dataset.dishId;
+                resetForm();
+                modal.show();
+            });
+        });
+    }
+    attachUploadHandlers();
+
+    // File input change handler - show preview
+    fileInput.addEventListener('change', function(e) {
+        const file = e.target.files[0];
+        if (!file) {
+            imagePreviewContainer.style.display = 'none';
+            return;
+        }
+
+        // Validate file type
+        const allowedTypes = ['image/jpeg', 'image/png', 'image/gif', 'image/webp'];
+        if (!allowedTypes.includes(file.type)) {
+            uploadError.textContent = 'Invalid file type. Please select a JPEG, PNG, GIF, or WebP image.';
+            uploadError.style.display = 'block';
+            fileInput.value = '';
+            imagePreviewContainer.style.display = 'none';
+            return;
+        }
+
+        // Validate file size (10MB max)
+        const maxSize = 10 * 1024 * 1024; // 10MB
+        if (file.size > maxSize) {
+            uploadError.textContent = 'File is too large. Maximum size is 10MB.';
+            uploadError.style.display = 'block';
+            fileInput.value = '';
+            imagePreviewContainer.style.display = 'none';
+            return;
+        }
+
+        // Clear any errors
+        uploadError.style.display = 'none';
+
+        // Show preview
+        const reader = new FileReader();
+        reader.onload = function(e) {
+            imagePreview.src = e.target.result;
+            imagePreviewContainer.style.display = 'block';
+        };
+        reader.readAsDataURL(file);
+    });
+
+    // Upload button click handler
+    uploadBtn.addEventListener('click', function() {
+        uploadImage();
+    });
+
+    // Reset form when modal is closed
+    modalElement.addEventListener('hidden.bs.modal', function() {
+        resetForm();
+        currentDishId = null;
+    });
+
+    function resetForm() {
+        uploadForm.reset();
+        imagePreviewContainer.style.display = 'none';
+        uploadError.style.display = 'none';
+        uploadSuccess.style.display = 'none';
+        imagePreview.src = '';
+        uploadBtn.disabled = false;
+        uploadBtnText.style.display = 'inline';
+        uploadBtnSpinner.style.display = 'none';
+        uploadBtnLoading.style.display = 'none';
+    }
+
+    function uploadImage() {
+        // Validate file is selected
+        const file = fileInput.files[0];
+        if (!file) {
+            uploadError.textContent = 'Please select an image file.';
+            uploadError.style.display = 'block';
+            return;
+        }
+
+        // Hide any previous messages
+        uploadError.style.display = 'none';
+        uploadSuccess.style.display = 'none';
+
+        // Show loading state
+        uploadBtn.disabled = true;
+        uploadBtnText.style.display = 'none';
+        uploadBtnSpinner.style.display = 'inline-block';
+        uploadBtnLoading.style.display = 'inline';
+
+        // Get CSRF token
+        const csrfToken = document.querySelector('[name=csrfmiddlewaretoken]')?.value ||
+                         getCookie('csrftoken');
+
+        // Prepare form data
+        const formData = new FormData();
+        formData.append('image', file);
+        formData.append('caption', captionInput.value.trim());
+        formData.append('alt_text', altTextInput.value.trim());
+        formData.append('order', 0); // Default order
+
+        // Upload the image
+        fetch(`/api/dishes/${currentDishId}/upload-image/`, {
+            method: 'POST',
+            headers: {
+                'X-CSRFToken': csrfToken
+            },
+            body: formData
+        })
+        .then(response => response.json())
+        .then(data => {
+            // Reset button state
+            uploadBtn.disabled = false;
+            uploadBtnText.style.display = 'inline';
+            uploadBtnSpinner.style.display = 'none';
+            uploadBtnLoading.style.display = 'none';
+
+            if (data.success) {
+                // Show success message
+                uploadSuccess.style.display = 'block';
+
+                // Update the page to show the new image
+                updateDishImages(currentDishId, data.image);
+
+                // Show toast notification
+                showToast('Success', 'Image uploaded successfully!', 'success');
+
+                // Close modal after a short delay
+                setTimeout(() => {
+                    modal.hide();
+                }, 1500);
+            } else {
+                uploadError.textContent = data.error || 'Failed to upload image.';
+                uploadError.style.display = 'block';
+            }
+        })
+        .catch(error => {
+            console.error('Upload error:', error);
+            uploadBtn.disabled = false;
+            uploadBtnText.style.display = 'inline';
+            uploadBtnSpinner.style.display = 'none';
+            uploadBtnLoading.style.display = 'none';
+            uploadError.textContent = 'Failed to upload image. Please try again.';
+            uploadError.style.display = 'block';
+        });
+    }
+
+    function updateDishImages(dishId, imageData) {
+        // Find the dish's image container
+        const uploadBtn = document.querySelector(`.upload-dish-image-btn[data-dish-id="${dishId}"]`);
+        if (!uploadBtn) return;
+
+        // Find the dish's list item
+        const listItem = uploadBtn.closest('.list-group-item');
+        if (!listItem) return;
+
+        // Find or create the images section
+        let imagesSection = listItem.querySelector('.dish-images');
+        if (!imagesSection) {
+            // Create images section if it doesn't exist
+            const h5 = listItem.querySelector('h5');
+            if (!h5) return;
+
+            imagesSection = document.createElement('div');
+            imagesSection.className = 'dish-images mt-2';
+            h5.insertAdjacentElement('afterend', imagesSection);
+        }
+
+        // Add the new image
+        const imageDiv = document.createElement('div');
+        imageDiv.className = 'd-inline-block me-2 mb-2';
+        imageDiv.innerHTML = `
+            <img src="${imageData.url}" alt="${imageData.alt_text || ''}"
+                 class="img-thumbnail" style="max-width: 150px; max-height: 150px;">
+            ${imageData.caption ? `<div class="small text-muted">${imageData.caption}</div>` : ''}
+        `;
+        imagesSection.appendChild(imageDiv);
+    }
+
+    function getCookie(name) {
+        let cookieValue = null;
+        if (document.cookie && document.cookie !== '') {
+            const cookies = document.cookie.split(';');
+            for (let i = 0; i < cookies.length; i++) {
+                const cookie = cookies[i].trim();
+                if (cookie.substring(0, name.length + 1) === (name + '=')) {
+                    cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
+                    break;
+                }
+            }
+        }
+        return cookieValue;
+    }
+
+    function showToast(title, message, type) {
+        // Simple toast notification
+        const alertDiv = document.createElement('div');
+        alertDiv.className = `alert alert-${type} alert-dismissible fade show position-fixed top-0 start-50 translate-middle-x mt-3`;
+        alertDiv.style.zIndex = '9999';
+        alertDiv.innerHTML = `
+            <strong>${title}:</strong> ${message}
+            <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
+        `;
+        document.body.appendChild(alertDiv);
+        setTimeout(() => alertDiv.remove(), 5000);
+    }
+});

--- a/templates/components/dish_image_upload_modal.html
+++ b/templates/components/dish_image_upload_modal.html
@@ -1,0 +1,62 @@
+<!-- Dish Image Upload Modal -->
+{% if user.is_staff %}
+<div class="modal fade" id="dishImageUploadModal" tabindex="-1" aria-labelledby="dishImageUploadModalLabel" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="dishImageUploadModalLabel">Upload Dish Photo</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <form id="dishImageUploadForm" enctype="multipart/form-data">
+                    {% csrf_token %}
+
+                    <!-- File Input -->
+                    <div class="mb-3">
+                        <label for="dishImageFile" class="form-label">Select Image <span class="text-danger">*</span></label>
+                        <input type="file" class="form-control" id="dishImageFile" name="image" accept="image/jpeg,image/png,image/gif,image/webp" required>
+                        <div class="form-text">Accepted formats: JPEG, PNG, GIF, WebP. Max size: 10MB</div>
+                    </div>
+
+                    <!-- Image Preview -->
+                    <div id="imagePreviewContainer" class="mb-3" style="display: none;">
+                        <label class="form-label">Preview</label>
+                        <div class="text-center">
+                            <img id="imagePreview" src="" alt="Preview" class="img-fluid rounded" style="max-height: 300px;">
+                        </div>
+                    </div>
+
+                    <!-- Caption -->
+                    <div class="mb-3">
+                        <label for="dishImageCaption" class="form-label">Caption (Optional)</label>
+                        <input type="text" class="form-control" id="dishImageCaption" name="caption" placeholder="Add a caption...">
+                    </div>
+
+                    <!-- Alt Text -->
+                    <div class="mb-3">
+                        <label for="dishImageAltText" class="form-label">Alt Text (Optional)</label>
+                        <input type="text" class="form-control" id="dishImageAltText" name="alt_text" placeholder="Describe the image for accessibility...">
+                        <div class="form-text">Helps screen readers describe the image</div>
+                    </div>
+
+                    <!-- Error Display -->
+                    <div id="uploadError" class="alert alert-danger" style="display: none;"></div>
+
+                    <!-- Success Display -->
+                    <div id="uploadSuccess" class="alert alert-success" style="display: none;">
+                        Image uploaded successfully!
+                    </div>
+                </form>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                <button type="button" class="btn btn-primary" id="uploadImageBtn">
+                    <span id="uploadBtnText"><i class="bi bi-upload"></i> Upload</span>
+                    <span id="uploadBtnSpinner" class="spinner-border spinner-border-sm" style="display: none;" role="status" aria-hidden="true"></span>
+                    <span id="uploadBtnLoading" style="display: none;">Uploading...</span>
+                </button>
+            </div>
+        </div>
+    </div>
+</div>
+{% endif %}

--- a/templates/review/detail.html
+++ b/templates/review/detail.html
@@ -128,6 +128,15 @@
                                     {% endif %}
                                 </div>
                                 {% endif %}
+                                {% if user.is_staff %}
+                                <div class="mb-2">
+                                    <button class="badge bg-info border-0 upload-dish-image-btn"
+                                            data-dish-id="{{ dish.id }}"
+                                            style="cursor: pointer;">
+                                        <i class="bi bi-camera"></i> Upload Photo
+                                    </button>
+                                </div>
+                                {% endif %}
                                 {% if dish.dish_rating %}
                                 <div class="mb-2">
                                     {{ dish.dish_rating|rating_to_stars }}
@@ -222,10 +231,14 @@
 
 <!-- Include Encyclopedia Link Modal -->
 {% include 'components/encyclopedia_link_modal.html' %}
+
+<!-- Include Dish Image Upload Modal -->
+{% include 'components/dish_image_upload_modal.html' %}
 {% endblock %}
 
 {% block extra_js %}
 {% if user.is_staff %}
 <script src="{% static 'js/encyclopedia_link.js' %}"></script>
+<script src="{% static 'js/dish_image_upload.js' %}"></script>
 {% endif %}
 {% endblock %}


### PR DESCRIPTION
Enable staff to upload images directly to dishes from the review detail page. Leverage modal pattern from encyclopedia linking to maintain UI consistency.

Enhance admin with ReviewDishAdmin and inline image management for comprehensive dish administration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)