### PR TITLE
FT-81: Simplify review dish filtering system

### DIFF
--- a/content/forms/review_dish_filter.py
+++ b/content/forms/review_dish_filter.py
@@ -1,12 +1,11 @@
 from django import forms
-from content.models import Encyclopedia
 
 
 class ReviewDishFilterForm(forms.Form):
     """
     Form for filtering and sorting review dishes on the review dish list page.
     """
-    # Text search filter - searches across dish name, notes, and encyclopedia name
+    # Text search filter - searches across dish name and encyclopedia name
     search = forms.CharField(
         required=False,
         max_length=255,
@@ -14,6 +13,17 @@ class ReviewDishFilterForm(forms.Form):
             'class': 'form-control',
             'id': 'search',
             'placeholder': 'Search dishes...'
+        })
+    )
+
+    # Restaurant search filter - searches restaurant names
+    restaurant_search = forms.CharField(
+        required=False,
+        max_length=255,
+        widget=forms.TextInput(attrs={
+            'class': 'form-control',
+            'id': 'restaurant_search',
+            'placeholder': 'Search restaurants...'
         })
     )
 
@@ -31,21 +41,6 @@ class ReviewDishFilterForm(forms.Form):
             'class': 'form-select',
             'id': 'link_status'
         })
-    )
-
-    # Restaurant name filter
-    restaurant = forms.CharField(
-        required=False,
-        max_length=255,
-        widget=forms.Select(attrs={'class': 'form-select', 'id': 'restaurant'})
-    )
-
-    # Encyclopedia entry filter
-    encyclopedia_entry = forms.ModelChoiceField(
-        required=False,
-        queryset=Encyclopedia.objects.none(),  # Will be populated in __init__
-        empty_label='All Encyclopedia Entries',
-        widget=forms.Select(attrs={'class': 'form-select', 'id': 'encyclopedia_entry'})
     )
 
     # Dish rating range filters
@@ -104,10 +99,6 @@ class ReviewDishFilterForm(forms.Form):
         ('link_desc', 'Encyclopedia Link: Z-A'),
     ]
 
-    SORT_CHOICES_WITH_RELEVANCE = [
-        ('relevance', 'Relevance'),
-    ] + SORT_CHOICES
-
     sort = forms.ChoiceField(
         required=False,
         choices=SORT_CHOICES,
@@ -118,34 +109,6 @@ class ReviewDishFilterForm(forms.Form):
             'onchange': 'document.getElementById("filterForm").submit()'
         })
     )
-
-    def __init__(self, *args, restaurant_choices=None, encyclopedia_choices=None, **kwargs):
-        """
-        Initialize form with dynamic choices for restaurant and encyclopedia entries.
-
-        Args:
-            restaurant_choices: List of (value, label) tuples for restaurant dropdown
-            encyclopedia_choices: QuerySet of Encyclopedia objects for encyclopedia dropdown
-        """
-        super().__init__(*args, **kwargs)
-
-        # Set restaurant choices
-        if restaurant_choices:
-            self.fields['restaurant'].widget = forms.Select(
-                choices=[('', 'All Restaurants')] + restaurant_choices,
-                attrs={'class': 'form-select', 'id': 'restaurant'}
-            )
-
-        # Set encyclopedia entry choices
-        if encyclopedia_choices:
-            self.fields['encyclopedia_entry'].queryset = encyclopedia_choices
-
-        # Add relevance sort option if search is active
-        if self.data and self.data.get('search'):
-            self.fields['sort'].choices = self.SORT_CHOICES_WITH_RELEVANCE
-            # Default to relevance when searching
-            if not self.data.get('sort'):
-                self.initial['sort'] = 'relevance'
 
     def clean(self):
         """

--- a/templates/review_dish/_filter_form.html
+++ b/templates/review_dish/_filter_form.html
@@ -1,7 +1,7 @@
 <form method="get" id="filterForm">
-    <!-- Search Section -->
+    <!-- Dish Search Section -->
     <div class="border-bottom p-3">
-        <h6 class="mb-3"><i class="bi bi-search"></i> Search</h6>
+        <h6 class="mb-3"><i class="bi bi-search"></i> Search Dishes</h6>
         <div class="input-group input-group-sm">
             <input type="text" class="form-control" id="search" name="search"
                    placeholder="Search dishes..."
@@ -13,7 +13,25 @@
             {% endif %}
         </div>
         <div class="form-text small mt-1">
-            Search dish names, notes, and encyclopedia entries
+            Search dish names and encyclopedia entries
+        </div>
+    </div>
+
+    <!-- Restaurant Search Section -->
+    <div class="border-bottom p-3">
+        <h6 class="mb-3"><i class="bi bi-shop"></i> Search Restaurants</h6>
+        <div class="input-group input-group-sm">
+            <input type="text" class="form-control" id="restaurant_search" name="restaurant_search"
+                   placeholder="Search restaurants..."
+                   value="{{ filter_params.restaurant_search }}">
+            {% if filter_params.restaurant_search %}
+            <button type="button" class="btn btn-outline-secondary" onclick="document.getElementById('restaurant_search').value=''; document.getElementById('filterForm').submit();">
+                <i class="bi bi-x"></i>
+            </button>
+            {% endif %}
+        </div>
+        <div class="form-text small mt-1">
+            Filter by restaurant name
         </div>
     </div>
 
@@ -24,32 +42,6 @@
             <option value="all" {% if filter_params.link_status == 'all' or not filter_params.link_status %}selected{% endif %}>All Dishes</option>
             <option value="linked" {% if filter_params.link_status == 'linked' %}selected{% endif %}>Linked to Encyclopedia</option>
             <option value="unlinked" {% if filter_params.link_status == 'unlinked' %}selected{% endif %}>Not Linked</option>
-        </select>
-    </div>
-
-    <!-- Restaurant Section -->
-    <div class="border-bottom p-3">
-        <h6 class="mb-3"><i class="bi bi-shop"></i> Restaurant</h6>
-        <select class="form-select form-select-sm" id="restaurant" name="restaurant">
-            <option value="">All Restaurants</option>
-            {% for restaurant in restaurant_options %}
-            <option value="{{ restaurant }}" {% if filter_params.restaurant == restaurant %}selected{% endif %}>
-                {{ restaurant }}
-            </option>
-            {% endfor %}
-        </select>
-    </div>
-
-    <!-- Encyclopedia Entry Section -->
-    <div class="border-bottom p-3">
-        <h6 class="mb-3"><i class="bi bi-book"></i> Encyclopedia Entry</h6>
-        <select class="form-select form-select-sm" id="encyclopedia_entry" name="encyclopedia_entry">
-            <option value="">All Entries</option>
-            {% for entry in encyclopedia_options %}
-            <option value="{{ entry.id }}" {% if filter_params.encyclopedia_entry.id == entry.id %}selected{% endif %}>
-                {{ entry.name }}
-            </option>
-            {% endfor %}
         </select>
     </div>
 
@@ -107,12 +99,7 @@
     <div class="border-bottom p-3">
         <h6 class="mb-3"><i class="bi bi-sort-down"></i> Sort By</h6>
         <select class="form-select form-select-sm" id="sort" name="sort">
-            {% if filter_params.search %}
-            <option value="relevance" {% if filter_params.sort == 'relevance' or not filter_params.sort %}selected{% endif %}>Relevance</option>
-            <option value="date_desc" {% if filter_params.sort == 'date_desc' %}selected{% endif %}>Date: Newest First</option>
-            {% else %}
             <option value="date_desc" {% if filter_params.sort == 'date_desc' or not filter_params.sort %}selected{% endif %}>Date: Newest First</option>
-            {% endif %}
             <option value="date_asc" {% if filter_params.sort == 'date_asc' %}selected{% endif %}>Date: Oldest First</option>
             <option value="rating_desc" {% if filter_params.sort == 'rating_desc' %}selected{% endif %}>Dish Rating: High to Low</option>
             <option value="rating_asc" {% if filter_params.sort == 'rating_asc' %}selected{% endif %}>Dish Rating: Low to High</option>

--- a/templates/review_dish/list.html
+++ b/templates/review_dish/list.html
@@ -173,10 +173,10 @@
                                        class="text-decoration-none text-dark review-link"
                                        data-review-id="{{ dish.review.id }}"
                                        data-review-url="{% url 'content:review_detail' dish.review.id %}">
-                                        {% if dish.encyclopedia_entry %}
-                                            {{ dish.encyclopedia_entry.name }}
-                                        {% elif dish.dish_name %}
+                                        {% if dish.dish_name %}
                                             {{ dish.dish_name }}
+                                        {% elif dish.encyclopedia_entry %}
+                                            {{ dish.encyclopedia_entry.name }}
                                         {% else %}
                                             <span class="text-muted fst-italic">Unnamed Dish</span>
                                         {% endif %}


### PR DESCRIPTION
Replace dropdown filters with text-based search fields to improve usability and simplify implementation. Remove PostgreSQL full-text search in favor of case-insensitive search across dish names, encyclopedia entries, and restaurant names.

Split single search field into separate dish and restaurant search inputs for more targeted filtering. Remove relevance sort option that depended on full-text search ranking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)