### PR TITLE
FT-89: Add similar dishes globally feature

### DIFF
--- a/content/views/encyclopedia_detail.py
+++ b/content/views/encyclopedia_detail.py
@@ -13,6 +13,10 @@ class EncyclopediaDetailView(DetailView):
     slug_field = 'slug'
     slug_url_kwarg = 'slug'
 
+    def get_queryset(self):
+        """Optimize queryset with prefetch_related for better performance."""
+        return Encyclopedia.objects.prefetch_related('similar_dishes')
+
     def get_context_data(self, **kwargs):
         """Add additional context for ancestors, children, and related content."""
         context = super().get_context_data(**kwargs)
@@ -40,6 +44,9 @@ class EncyclopediaDetailView(DetailView):
             .prefetch_related('images', 'review__images')
             .order_by('-review__visit_date', '-review__entry_time')
         )
+
+        # Add similar dishes with optimized query
+        context['similar_dishes'] = entry.similar_dishes.all().order_by('name')
 
         # Add tree entries for sidebar navigation with full tree structure
         root_entries = (

--- a/templates/components/encyclopedia_link_modal.html
+++ b/templates/components/encyclopedia_link_modal.html
@@ -84,6 +84,20 @@
                                 <button type="button" class="btn-close float-end" id="clearParent" aria-label="Clear"></button>
                             </div>
                         </div>
+                        <div class="mb-3">
+                            <label for="entrySimilarDishesSearch" class="form-label">Similar Dishes Globally (Optional)</label>
+                            <input type="text" class="form-control" id="entrySimilarDishesSearch" placeholder="Search for similar dishes...">
+                            <div class="form-text">Link to similar dishes from other cuisines</div>
+                            <div id="similarDishesSearchResults" class="list-group mt-2" style="max-height: 200px; overflow-y: auto; display: none;">
+                                <!-- Similar dishes search results will be populated here -->
+                            </div>
+                            <div id="selectedSimilarDishes" class="mt-2" style="display: none;">
+                                <strong class="d-block mb-2">Selected Similar Dishes:</strong>
+                                <div id="similarDishesChips" class="d-flex flex-wrap gap-2">
+                                    <!-- Selected similar dishes chips will be populated here -->
+                                </div>
+                            </div>
+                        </div>
                         <div id="createFormError" class="alert alert-danger" style="display: none;"></div>
                     </form>
                 </div>

--- a/templates/encyclopedia/detail.html
+++ b/templates/encyclopedia/detail.html
@@ -295,6 +295,52 @@
 </div>
 {% endif %}
 
+<!-- Similar Dishes Globally -->
+{% if similar_dishes %}
+<div class="row mt-4">
+    <div class="col-12">
+        <div class="card">
+            <div class="card-header">
+                <h4 class="mb-0">Similar Dishes Globally</h4>
+            </div>
+            <div class="card-body">
+                <div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-4">
+                    {% for similar_dish in similar_dishes %}
+                    <div class="col">
+                        <div class="card h-100">
+                            <div class="card-body">
+                                <h5 class="card-title">
+                                    <a href="{% url 'content:encyclopedia_detail' similar_dish.slug %}" class="text-decoration-none">
+                                        {{ similar_dish.name }}
+                                    </a>
+                                </h5>
+                                {% if similar_dish.get_hierarchy_breadcrumb %}
+                                <p class="card-text text-muted small mb-2">
+                                    <i class="bi bi-diagram-3"></i> {{ similar_dish.get_hierarchy_breadcrumb }}
+                                </p>
+                                {% endif %}
+                                {% if similar_dish.description %}
+                                <p class="card-text small">{{ similar_dish.description|truncatewords:20 }}</p>
+                                {% endif %}
+                                <div class="mt-2">
+                                    {% if similar_dish.cuisine_type %}
+                                    <span class="badge bg-secondary">{{ similar_dish.cuisine_type }}</span>
+                                    {% endif %}
+                                    {% if similar_dish.dish_category %}
+                                    <span class="badge bg-info">{{ similar_dish.dish_category }}</span>
+                                    {% endif %}
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    {% endfor %}
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+{% endif %}
+
 <!-- Back Button -->
 <div class="row mt-4">
     <div class="col-12">


### PR DESCRIPTION
Enable linking encyclopedia entries to similar dishes from different cuisines worldwide (e.g., Ramen to Ramyun, Pho).

Add searchable multi-select field in encyclopedia modal with chip-based UI for managing selected similar dishes. Optimize query performance using prefetch_related to prevent N+1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)