### PR TITLE
FT-95: Display placeholders in Similar Dishes

### DIFF
--- a/content/views/encyclopedia_detail.py
+++ b/content/views/encyclopedia_detail.py
@@ -14,8 +14,12 @@ class EncyclopediaDetailView(DetailView):
     slug_url_kwarg = 'slug'
 
     def get_queryset(self):
-        """Optimize queryset with prefetch_related for better performance."""
-        return Encyclopedia.objects.prefetch_related('similar_dishes')
+        """
+        Optimize queryset with prefetch_related for better performance.
+        Note: We don't prefetch similar_dishes here because it's a symmetrical ManyToMany
+        relationship, which would cause infinite recursion during prefetch.
+        """
+        return Encyclopedia.objects.all()
 
     def get_context_data(self, **kwargs):
         """Add additional context for ancestors, children, and related content."""
@@ -46,7 +50,8 @@ class EncyclopediaDetailView(DetailView):
         )
 
         # Add similar dishes with optimized query
-        context['similar_dishes'] = entry.similar_dishes.all().order_by('name')
+        # Convert to list to prevent recursion issues with symmetrical ManyToMany relationship
+        context['similar_dishes'] = list(entry.similar_dishes.all().order_by('name'))
 
         # Add tree entries for sidebar navigation with full tree structure
         root_entries = (

--- a/static/css/encyclopedia_tree.css
+++ b/static/css/encyclopedia_tree.css
@@ -759,6 +759,109 @@
     outline-offset: 2px;
 }
 
+/* ============================================
+   SIMILAR DISH CARD STYLES
+   ============================================ */
+
+/* Base Card Styles */
+.similar-dish-card__link {
+    color: inherit;
+    transition: color 0.2s ease;
+}
+
+.similar-dish-card__link:hover {
+    color: #2563eb;
+}
+
+.similar-dish-card__link:focus {
+    outline: 2px solid #2563eb;
+    outline-offset: 2px;
+    border-radius: 0.25rem;
+}
+
+/* Placeholder Card Styles */
+.similar-dish-card--placeholder {
+    background: rgba(0, 0, 0, 0.02);
+    border: 1px dashed #d1d5db;
+}
+
+.similar-dish-card--placeholder:hover {
+    background: rgba(0, 0, 0, 0.04);
+}
+
+/* Placeholder Link (Admin Users) */
+.similar-dish-card__link--placeholder-admin {
+    color: #6b7280 !important;
+    font-style: italic;
+    transition: color 0.2s ease;
+}
+
+.similar-dish-card__link--placeholder-admin:hover {
+    color: #1f2937 !important;
+    text-decoration: underline;
+}
+
+.similar-dish-card__link--placeholder-admin:focus {
+    outline: 2px solid #2563eb;
+    outline-offset: 2px;
+    border-radius: 0.25rem;
+}
+
+.similar-dish-card__link--placeholder-admin .similar-dish-card__name {
+    font-style: italic;
+}
+
+/* Placeholder Text (Regular Users) */
+.similar-dish-card__text--placeholder {
+    color: #9ca3af;
+    font-style: italic;
+    cursor: default;
+}
+
+/* Placeholder Badge Styling */
+.similar-dish-card__link--placeholder-admin .badge,
+.similar-dish-card__text--placeholder .badge {
+    font-style: normal;
+    font-size: 0.75rem;
+    font-weight: 600;
+}
+
+/* Responsive Design */
+@media (max-width: 768px) {
+    .similar-dish-card__link--placeholder-admin,
+    .similar-dish-card__text--placeholder {
+        font-size: 0.875rem;
+    }
+
+    .similar-dish-card__link--placeholder-admin .badge,
+    .similar-dish-card__text--placeholder .badge {
+        font-size: 0.625rem;
+        padding: 0.25rem 0.4rem;
+    }
+}
+
+/* Accessibility: High Contrast Mode */
+@media (prefers-contrast: high) {
+    .similar-dish-card--placeholder {
+        border-width: 2px;
+        border-color: #6b7280;
+    }
+
+    .similar-dish-card__link--placeholder-admin,
+    .similar-dish-card__text--placeholder {
+        font-weight: 600;
+    }
+}
+
+/* Accessibility: Reduced Motion */
+@media (prefers-reduced-motion: reduce) {
+    .similar-dish-card__link,
+    .similar-dish-card__link--placeholder-admin,
+    .similar-dish-card--placeholder {
+        transition: none;
+    }
+}
+
 /* Print Styles */
 @media print {
     .encyclopedia-sidebar,
@@ -769,5 +872,16 @@
 
     .encyclopedia-main-wrapper {
         margin-left: 0 !important;
+    }
+
+    /* Hide placeholder badges in print */
+    .similar-dish-card__link--placeholder-admin .badge,
+    .similar-dish-card__text--placeholder .badge {
+        display: none;
+    }
+
+    /* Remove dashed border for print */
+    .similar-dish-card--placeholder {
+        border-style: solid;
     }
 }

--- a/static/js/encyclopedia_tree.js
+++ b/static/js/encyclopedia_tree.js
@@ -680,6 +680,14 @@
                 }
             });
         });
+
+        // Initialize Bootstrap tooltips for placeholder entries
+        const tooltipTriggerList = document.querySelectorAll('[data-bs-toggle="tooltip"]');
+        if (tooltipTriggerList.length > 0 && typeof bootstrap !== 'undefined') {
+            [...tooltipTriggerList].map(tooltipTriggerEl =>
+                new bootstrap.Tooltip(tooltipTriggerEl)
+            );
+        }
     }
 
     // Run on DOM ready

--- a/templates/encyclopedia/detail.html
+++ b/templates/encyclopedia/detail.html
@@ -307,22 +307,53 @@
                 <div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-4">
                     {% for similar_dish in similar_dishes %}
                     <div class="col">
-                        <div class="card h-100">
+                        <div class="card h-100 similar-dish-card {% if similar_dish.is_placeholder %}similar-dish-card--placeholder{% endif %}">
                             <div class="card-body">
                                 <h5 class="card-title">
-                                    <a href="{% url 'content:encyclopedia_detail' similar_dish.slug %}" class="text-decoration-none">
-                                        {{ similar_dish.name }}
-                                    </a>
+                                    {% if similar_dish.is_placeholder %}
+                                        {% if user.is_staff %}
+                                            {# Admin users: clickable placeholder with visual indicator #}
+                                            <a href="{% url 'content:encyclopedia_detail' similar_dish.slug %}"
+                                               class="text-decoration-none similar-dish-card__link similar-dish-card__link--placeholder-admin"
+                                               data-bs-toggle="tooltip"
+                                               data-bs-placement="top"
+                                               title="Placeholder entry - Click to edit and complete">
+                                                <i class="bi bi-pencil-square me-1"></i>
+                                                <span class="similar-dish-card__name">{{ similar_dish.name }}</span>
+                                                <span class="badge bg-warning text-dark ms-2">Stub</span>
+                                            </a>
+                                        {% else %}
+                                            {# Regular users: plain text placeholder #}
+                                            <span class="similar-dish-card__text similar-dish-card__text--placeholder"
+                                                  data-bs-toggle="tooltip"
+                                                  data-bs-placement="top"
+                                                  title="This is a placeholder entry that hasn't been completed yet">
+                                                {{ similar_dish.name }}
+                                                <span class="badge bg-secondary ms-2">Incomplete</span>
+                                            </span>
+                                        {% endif %}
+                                    {% else %}
+                                        {# Complete entries: normal rendering #}
+                                        <a href="{% url 'content:encyclopedia_detail' similar_dish.slug %}"
+                                           class="text-decoration-none similar-dish-card__link">
+                                            {{ similar_dish.name }}
+                                        </a>
+                                    {% endif %}
                                 </h5>
+
                                 {% if similar_dish.get_hierarchy_breadcrumb %}
-                                <p class="card-text text-muted small mb-2">
+                                <p class="card-text text-muted small mb-2 similar-dish-card__breadcrumb">
                                     <i class="bi bi-diagram-3"></i> {{ similar_dish.get_hierarchy_breadcrumb }}
                                 </p>
                                 {% endif %}
+
                                 {% if similar_dish.description %}
-                                <p class="card-text small">{{ similar_dish.description|truncatewords:20 }}</p>
+                                <p class="card-text small similar-dish-card__description">
+                                    {{ similar_dish.description|truncatewords:20 }}
+                                </p>
                                 {% endif %}
-                                <div class="mt-2">
+
+                                <div class="mt-2 similar-dish-card__badges">
                                     {% if similar_dish.cuisine_type %}
                                     <span class="badge bg-secondary">{{ similar_dish.cuisine_type }}</span>
                                     {% endif %}


### PR DESCRIPTION
Add conditional rendering to show placeholder entries differently for admin vs regular users. Admins see clickable stubs with edit icon and "Stub" badge;
regular users see non-clickable text with "Incomplete" badge. Use BEM naming for CSS classes to maintain
consistency with existing encyclopedia styles.

Fix ManyToMany recursion by converting similar_dishes to list instead of prefetching the symmetrical
relationship, which would cause infinite recursion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)