### PR TITLE
FT-97: Add bulk placeholder creation from admin

### DIFF
--- a/content/admin/encyclopedia.py
+++ b/content/admin/encyclopedia.py
@@ -130,6 +130,12 @@ class EncyclopediaAdmin(admin.ModelAdmin):
 
     class Media:
         css = {
-            'all': ('admin/css/encyclopedia_placeholder.css',)
+            'all': (
+                'admin/css/encyclopedia_placeholder.css',
+                'admin/css/encyclopedia_quick_create.css',
+            )
         }
-        js = ('admin/js/encyclopedia_placeholder.js',)
+        js = (
+            'admin/js/encyclopedia_placeholder.js',
+            'admin/js/encyclopedia_quick_create.js',
+        )

--- a/content/urls.py
+++ b/content/urls.py
@@ -18,6 +18,7 @@ urlpatterns = [
     path('api/encyclopedia/search/', views.EncyclopediaSearchApiView.as_view(), name='api_encyclopedia_search'),
     path('api/encyclopedia/suggest/', views.EncyclopediaSuggestApiView.as_view(), name='api_encyclopedia_suggest'),
     path('api/encyclopedia/create/', views.EncyclopediaCreateApiView.as_view(), name='api_encyclopedia_create'),
+    path('api/encyclopedia/create-placeholder/', views.EncyclopediaQuickCreateApiView.as_view(), name='api_encyclopedia_quick_create'),
     path('api/encyclopedia/<int:entry_id>/set-parent/', views.EncyclopediaParentApiView.as_view(), name='api_encyclopedia_set_parent'),
     path('api/encyclopedia/<int:entry_id>/convert/', views.EncyclopediaConvertApiView.as_view(), name='api_encyclopedia_convert'),
     path('api/dishes/<int:dish_id>/link/', views.DishLinkApiView.as_view(), name='api_dish_link'),

--- a/content/views/__init__.py
+++ b/content/views/__init__.py
@@ -7,6 +7,7 @@ from .encyclopedia_suggest_api import EncyclopediaSuggestApiView
 from .encyclopedia_create_api import EncyclopediaCreateApiView
 from .encyclopedia_parent_api import EncyclopediaParentApiView
 from .encyclopedia_convert_api import EncyclopediaConvertApiView
+from .encyclopedia_quick_create_api import EncyclopediaQuickCreateApiView
 from .dish_link_api import DishLinkApiView
 from .dish_image_api import DishImageUploadApiView
 from .review_list import ReviewListView
@@ -26,6 +27,7 @@ __all__ = [
     'EncyclopediaCreateApiView',
     'EncyclopediaParentApiView',
     'EncyclopediaConvertApiView',
+    'EncyclopediaQuickCreateApiView',
     'DishLinkApiView',
     'DishImageUploadApiView',
     'ReviewListView',

--- a/content/views/encyclopedia_quick_create_api.py
+++ b/content/views/encyclopedia_quick_create_api.py
@@ -1,0 +1,104 @@
+from django.http import JsonResponse
+from django.views import View
+from django.utils.decorators import method_decorator
+from django.contrib.auth.decorators import login_required, user_passes_test
+from django.utils.text import slugify
+from django.core.exceptions import ValidationError
+from django.db import IntegrityError
+from content.models import Encyclopedia
+import json
+
+
+def is_staff_user(user):
+    """Check if user is staff."""
+    return user.is_staff
+
+
+@method_decorator([login_required, user_passes_test(is_staff_user)], name='dispatch')
+class EncyclopediaQuickCreateApiView(View):
+    """
+    API endpoint for quickly creating placeholder Encyclopedia entries.
+    Used for inline creation from the similar dishes selection interface.
+    Requires authentication and staff permissions.
+    """
+
+    def post(self, request, *args, **kwargs):
+        """
+        Create a new placeholder encyclopedia entry.
+        POST body: {
+            "name": str (required),
+            "source_entry_id": int (optional - if provided, links as similar dish)
+        }
+        """
+        try:
+            # Parse request body
+            data = json.loads(request.body)
+
+            # Extract fields
+            name = data.get('name', '').strip()
+            source_entry_id = data.get('source_entry_id')
+
+            # Validate required field
+            if not name:
+                return JsonResponse({'error': 'Name is required'}, status=400)
+
+            # Check for duplicate name
+            if Encyclopedia.objects.filter(name__iexact=name).exists():
+                return JsonResponse({
+                    'error': f'An encyclopedia entry with the name "{name}" already exists'
+                }, status=400)
+
+            # Generate slug
+            base_slug = slugify(name)
+            slug = base_slug
+            counter = 1
+
+            # Handle duplicate slugs by appending a number
+            while Encyclopedia.objects.filter(slug=slug).exists():
+                slug = f"{base_slug}-{counter}"
+                counter += 1
+
+            # Create the placeholder encyclopedia entry
+            encyclopedia_entry = Encyclopedia(
+                name=name,
+                slug=slug,
+                description='',  # Empty description for placeholder
+                is_placeholder=True,  # Mark as placeholder
+                created_by=request.user
+            )
+
+            # Validate and save
+            try:
+                encyclopedia_entry.full_clean()
+                encyclopedia_entry.save()
+            except ValidationError as e:
+                return JsonResponse({'error': str(e)}, status=400)
+
+            # Link to source entry as similar dish if provided
+            if source_entry_id:
+                try:
+                    source_entry = Encyclopedia.objects.get(id=source_entry_id)
+                    # Add the new placeholder to the source entry's similar dishes
+                    # Since similar_dishes is symmetrical, this also adds source to the placeholder's similar dishes
+                    source_entry.similar_dishes.add(encyclopedia_entry)
+                except Encyclopedia.DoesNotExist:
+                    # Source entry not found, but we still created the placeholder successfully
+                    pass
+
+            # Return success response with minimal data for widget integration
+            return JsonResponse({
+                'success': True,
+                'entry': {
+                    'id': encyclopedia_entry.id,
+                    'name': encyclopedia_entry.name,
+                    'slug': encyclopedia_entry.slug,
+                    'is_placeholder': encyclopedia_entry.is_placeholder,
+                }
+            })
+
+        except json.JSONDecodeError:
+            return JsonResponse({'error': 'Invalid JSON'}, status=400)
+        except IntegrityError as e:
+            return JsonResponse({'error': f'Database error: {str(e)}'}, status=500)
+        except Exception as e:
+            return JsonResponse({'error': str(e)}, status=500)

--- a/static/admin/css/encyclopedia_quick_create.css
+++ b/static/admin/css/encyclopedia_quick_create.css
@@ -1,0 +1,192 @@
+/* Quick Create Placeholder Button */
+.quick-create-placeholder-btn {
+    display: inline-block;
+    margin-bottom: 10px;
+    padding: 8px 15px;
+    background-color: #417690;
+    color: white !important;
+    border-radius: 4px;
+    text-decoration: none;
+    font-size: 13px;
+    font-weight: 500;
+    transition: background-color 0.2s;
+}
+
+.quick-create-placeholder-btn:hover {
+    background-color: #205067;
+    color: white !important;
+    text-decoration: none;
+}
+
+/* Modal */
+.quick-create-modal {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    z-index: 10000;
+}
+
+.quick-create-modal-overlay {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.5);
+}
+
+.quick-create-modal-content {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    background: white;
+    border-radius: 6px;
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+    padding: 24px;
+    min-width: 500px;
+    max-width: 600px;
+}
+
+.quick-create-modal-content h2 {
+    margin: 0 0 20px 0;
+    font-size: 18px;
+    color: #333;
+    border-bottom: 1px solid #e0e0e0;
+    padding-bottom: 10px;
+}
+
+/* Form */
+#quick-create-form .form-group {
+    margin-bottom: 16px;
+}
+
+#quick-create-form label {
+    display: block;
+    margin-bottom: 6px;
+    font-weight: 600;
+    color: #333;
+    font-size: 13px;
+}
+
+#quick-create-form label .required {
+    color: #cc3434;
+    font-weight: bold;
+}
+
+#quick-create-form input[type="text"],
+#quick-create-form textarea {
+    width: 100%;
+    padding: 8px 10px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    font-size: 14px;
+    box-sizing: border-box;
+    transition: border-color 0.2s;
+}
+
+#quick-create-form input[type="text"]:focus,
+#quick-create-form textarea:focus {
+    outline: none;
+    border-color: #417690;
+    box-shadow: 0 0 0 3px rgba(65, 118, 144, 0.1);
+}
+
+#quick-create-form textarea {
+    resize: vertical;
+    min-height: 120px;
+}
+
+#quick-create-form .help-text {
+    margin: 4px 0 0 0;
+    font-size: 12px;
+    color: #666;
+    font-style: italic;
+}
+
+/* Error Message */
+.quick-create-modal .error-message {
+    background-color: #fce4e4;
+    border: 1px solid #fcc2c3;
+    border-radius: 4px;
+    color: #cc0033;
+    padding: 10px 12px;
+    margin-bottom: 16px;
+    font-size: 13px;
+}
+
+/* Progress Bar */
+.quick-create-modal .progress-bar {
+    position: relative;
+    width: 100%;
+    height: 30px;
+    background-color: #f0f0f0;
+    border-radius: 4px;
+    margin-bottom: 16px;
+    overflow: hidden;
+}
+
+.quick-create-modal .progress-fill {
+    position: absolute;
+    top: 0;
+    left: 0;
+    height: 100%;
+    background-color: #417690;
+    transition: width 0.3s ease;
+}
+
+.quick-create-modal .progress-text {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    font-size: 13px;
+    font-weight: 600;
+    color: #333;
+    z-index: 1;
+}
+
+/* Buttons */
+.quick-create-modal .button-group {
+    display: flex;
+    gap: 10px;
+    justify-content: flex-end;
+    margin-top: 20px;
+    padding-top: 16px;
+    border-top: 1px solid #e0e0e0;
+}
+
+.quick-create-modal .button {
+    padding: 8px 16px;
+    border: none;
+    border-radius: 4px;
+    font-size: 13px;
+    font-weight: 500;
+    cursor: pointer;
+    transition: background-color 0.2s, opacity 0.2s;
+}
+
+.quick-create-modal .button.primary {
+    background-color: #417690;
+    color: white;
+}
+
+.quick-create-modal .button.primary:hover {
+    background-color: #205067;
+}
+
+.quick-create-modal .button.primary:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+}
+
+.quick-create-modal .button.cancel {
+    background-color: #e0e0e0;
+    color: #333;
+}
+
+.quick-create-modal .button.cancel:hover {
+    background-color: #c0c0c0;
+}

--- a/static/admin/js/encyclopedia_quick_create.js
+++ b/static/admin/js/encyclopedia_quick_create.js
@@ -1,0 +1,334 @@
+(function($) {
+    'use strict';
+
+    $(document).ready(function() {
+        // Only run on encyclopedia admin change form
+        // Django's filter_horizontal creates elements with specific class/id patterns
+        var $similarDishesRow = $('.form-row.field-similar_dishes');
+
+        if ($similarDishesRow.length === 0) {
+            return; // Not on the encyclopedia admin page with similar_dishes field
+        }
+
+        // Add "Create Placeholder" button above the filter_horizontal widget
+        var $createButton = $('<a>', {
+            'href': '#',
+            'class': 'quick-create-placeholder-btn',
+            'text': '+ Create Placeholder'
+        });
+
+        // Insert button before the selector
+        $similarDishesRow.prepend($createButton);
+
+        // Get the current encyclopedia entry ID from the URL
+        // URL format: /admin/content/encyclopedia/{id}/change/
+        var currentEntryId = null;
+        var urlMatch = window.location.pathname.match(/\/encyclopedia\/(\d+)\/change\//);
+        if (urlMatch) {
+            currentEntryId = parseInt(urlMatch[1]);
+            console.log('Current encyclopedia entry ID:', currentEntryId);
+        }
+
+        // Find the encyclopedia form (NOT the logout form!)
+        var $form = $('form#encyclopedia_form');
+        if ($form.length === 0) {
+            console.error('Could not find form#encyclopedia_form');
+            return;
+        }
+        console.log('Attaching submit handler to form#encyclopedia_form');
+
+        // Ensure all options in "to" select are selected on form submit
+        // This is required for Django's filter_horizontal to work properly
+        $form.on('submit', function(e) {
+            console.log('=== FORM SUBMIT EVENT ===');
+
+            // Check ALL select elements that might be related
+            console.log('Checking for similar_dishes select elements:');
+            var $mainSelect = $('#id_similar_dishes');
+            var $fromSelect = $('#id_similar_dishes_from');
+            var $toSelect = $('#id_similar_dishes_to');
+
+            console.log('id_similar_dishes (main):', $mainSelect.length, $mainSelect.length > 0 ? 'exists, visible=' + $mainSelect.is(':visible') + ', options=' + $mainSelect[0].options.length : 'NOT FOUND');
+            console.log('id_similar_dishes_from:', $fromSelect.length, 'visible=' + $fromSelect.is(':visible'), 'options=' + $fromSelect[0].options.length);
+            console.log('id_similar_dishes_to:', $toSelect.length, 'visible=' + $toSelect.is(':visible'), 'options=' + $toSelect[0].options.length);
+
+            // Select all in all of them
+            if ($mainSelect.length > 0) {
+                console.log('Selecting all in MAIN select');
+                $mainSelect.find('option').prop('selected', true);
+                console.log('  Main select selected:', $mainSelect.find('option:selected').length);
+            }
+
+            $toSelect.find('option').prop('selected', true);
+            console.log('  To select selected:', $toSelect.find('option:selected').length);
+        });
+
+        // Also handle Save buttons directly - use mousedown to run BEFORE the submit
+        $('input[name="_save"], input[name="_continue"], input[name="_addanother"]').on('mousedown', function() {
+            console.log('=== Save button mousedown ===');
+
+            // Log all similar_dishes selects
+            $('select[id*="similar_dishes"]').each(function() {
+                var $select = $(this);
+                console.log('Select:', this.id);
+                console.log('  Total options:', this.options.length);
+                console.log('  Selected before:', $select.find('option:selected').length);
+
+                // Select all options
+                $select.find('option').prop('selected', true);
+
+                console.log('  Selected after:', $select.find('option:selected').length);
+                console.log('  Options:', Array.from(this.options).map(o => ({value: o.value, text: o.text, selected: o.selected})));
+            });
+        });
+
+        // Create modal HTML
+        var modalHtml = `
+            <div id="quick-create-modal" class="quick-create-modal" style="display: none;">
+                <div class="quick-create-modal-overlay"></div>
+                <div class="quick-create-modal-content">
+                    <h2>Create New Placeholders</h2>
+                    <form id="quick-create-form">
+                        <div class="form-group">
+                            <label for="quick-create-names">Placeholder Names <span class="required">*</span></label>
+                            <textarea id="quick-create-names" name="names" required rows="8" autocomplete="off" style="font-family: monospace;"></textarea>
+                            <p class="help-text">Enter one placeholder name per line. All will be linked as similar dishes.</p>
+                        </div>
+                        <div class="error-message" style="display: none;"></div>
+                        <div class="progress-bar" style="display: none;">
+                            <div class="progress-fill"></div>
+                            <div class="progress-text">0%</div>
+                        </div>
+                        <div class="button-group">
+                            <button type="submit" class="button primary">Create Placeholders</button>
+                            <button type="button" class="button cancel">Cancel</button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        `;
+        $('body').append(modalHtml);
+
+        var $modal = $('#quick-create-modal');
+        var $form = $('#quick-create-form');
+        var $namesInput = $('#quick-create-names');
+        var $errorMessage = $modal.find('.error-message');
+        var $progressBar = $modal.find('.progress-bar');
+        var $progressFill = $modal.find('.progress-fill');
+        var $progressText = $modal.find('.progress-text');
+
+        // Show modal
+        function showModal() {
+            $modal.fadeIn(200);
+            $namesInput.val('').focus();
+            $errorMessage.hide().text('');
+            $progressBar.hide();
+        }
+
+        // Hide modal
+        function hideModal() {
+            $modal.css('display', 'none');
+            $namesInput.val('');
+            $errorMessage.hide().text('');
+            $progressBar.hide();
+        }
+
+        // Show error message
+        function showError(message) {
+            $errorMessage.text(message).fadeIn(200);
+        }
+
+        // Get CSRF token
+        function getCookie(name) {
+            var cookieValue = null;
+            if (document.cookie && document.cookie !== '') {
+                var cookies = document.cookie.split(';');
+                for (var i = 0; i < cookies.length; i++) {
+                    var cookie = cookies[i].trim();
+                    if (cookie.substring(0, name.length + 1) === (name + '=')) {
+                        cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
+                        break;
+                    }
+                }
+            }
+            return cookieValue;
+        }
+
+        // Add new entry to filter_horizontal widget
+        function addEntryToWidget(entry) {
+            console.log('Adding entry to widget:', entry);
+
+            // Django's filter_horizontal creates BOTH hidden selects AND visual selector boxes
+            // We need to update both the hidden select AND the visible select in the selector-chosen div
+
+            // Debug: Let's see ALL select elements for similar_dishes
+            console.log('All selects with similar_dishes in ID:');
+            $('select[id*="similar_dishes"]').each(function() {
+                console.log('  -', this.id, 'options:', this.options.length, 'visible:', $(this).is(':visible'));
+            });
+
+            // First, find the visual selector boxes
+            var $selectorChosen = $('.selector-chosen select');
+            var $hiddenToSelect = $('#id_similar_dishes_to');
+
+            console.log('Found selector-chosen select:', $selectorChosen.length, 'ID:', $selectorChosen.attr('id'));
+            console.log('Found hidden to select:', $hiddenToSelect.length);
+
+            if ($selectorChosen.length === 0 && $hiddenToSelect.length === 0) {
+                console.error('Could not find any filter_horizontal select elements');
+                return;
+            }
+
+            // Create new option element
+            var displayText = entry.name;
+            var $newOption = $('<option>', {
+                value: entry.id,
+                text: displayText,
+                selected: true,
+                title: displayText
+            });
+
+            // Add to the VISIBLE selector-chosen select (this is what users see)
+            if ($selectorChosen.length > 0) {
+                $selectorChosen.append($newOption.clone());
+                sortSelectOptions($selectorChosen);
+                console.log('Added to visual selector-chosen');
+            }
+
+            // Add to the HIDDEN "to" select (this is what gets submitted)
+            if ($hiddenToSelect.length > 0) {
+                $hiddenToSelect.append($newOption.clone());
+                sortSelectOptions($hiddenToSelect);
+                console.log('Added to hidden to select');
+            }
+
+            // Ensure it's selected in both
+            $selectorChosen.find('option[value="' + entry.id + '"]').prop('selected', true);
+            $hiddenToSelect.find('option[value="' + entry.id + '"]').prop('selected', true);
+
+            console.log('Entry added successfully');
+        }
+
+        // Sort select options alphabetically
+        function sortSelectOptions($select) {
+            var options = $select.find('option').toArray();
+            options.sort(function(a, b) {
+                return a.text.localeCompare(b.text);
+            });
+            $select.empty().append(options);
+        }
+
+        // Handle form submission
+        $form.on('submit', async function(e) {
+            e.preventDefault();
+
+            var input = $namesInput.val().trim();
+            if (!input) {
+                showError('Please enter at least one placeholder name');
+                return;
+            }
+
+            // Parse lines (split by newline, filter empty lines, trim each)
+            var names = input
+                .split('\n')
+                .map(function(line) { return line.trim(); })
+                .filter(function(line) { return line.length > 0; });
+
+            if (names.length === 0) {
+                showError('Please enter at least one placeholder name');
+                return;
+            }
+
+            // Hide error message
+            $errorMessage.hide();
+
+            // Show progress bar
+            $progressBar.show();
+            $progressFill.css('width', '0%');
+            $progressText.text('0%');
+
+            // Disable form during submission
+            var $submitButton = $form.find('button[type="submit"]');
+            $submitButton.prop('disabled', true).text('Creating...');
+
+            var errors = [];
+            var completed = 0;
+
+            // Create placeholders one by one
+            for (var i = 0; i < names.length; i++) {
+                var name = names[i];
+                var percent = Math.round(((i + 1) / names.length) * 100);
+
+                var requestData = {
+                    name: name
+                };
+
+                // If we're editing an existing entry, link it as a similar dish
+                if (currentEntryId) {
+                    requestData.source_entry_id = currentEntryId;
+                }
+
+                try {
+                    var response = await $.ajax({
+                        url: '/api/encyclopedia/create-placeholder/',
+                        type: 'POST',
+                        headers: {
+                            'X-CSRFToken': getCookie('csrftoken'),
+                            'Content-Type': 'application/json'
+                        },
+                        data: JSON.stringify(requestData)
+                    });
+
+                    if (response.success) {
+                        completed++;
+                    } else {
+                        errors.push(name + ': ' + (response.error || 'Failed to create'));
+                    }
+                } catch (xhr) {
+                    var errorMsg = 'Network error';
+                    if (xhr.responseJSON && xhr.responseJSON.error) {
+                        errorMsg = xhr.responseJSON.error;
+                    }
+                    errors.push(name + ': ' + errorMsg);
+                }
+
+                // Update progress
+                $progressFill.css('width', percent + '%');
+                $progressText.text(percent + '% (' + (i + 1) + '/' + names.length + ')');
+            }
+
+            // All done
+            if (completed > 0) {
+                // Reload the page to show the updated similar dishes
+                window.location.reload();
+            } else {
+                // All failed
+                showError('Failed to create placeholders: ' + errors.join(', '));
+                $submitButton.prop('disabled', false).text('Create Placeholders');
+                $progressBar.hide();
+            }
+        });
+
+        // Button click handlers
+        $createButton.on('click', function(e) {
+            e.preventDefault();
+            showModal();
+        });
+
+        $modal.find('.cancel').on('click', function() {
+            hideModal();
+        });
+
+        // Close modal when clicking overlay
+        $modal.find('.quick-create-modal-overlay').on('click', function() {
+            hideModal();
+        });
+
+        // Close modal on Escape key
+        $(document).on('keydown', function(e) {
+            if (e.key === 'Escape' && $modal.is(':visible')) {
+                hideModal();
+            }
+        });
+    });
+})(django.jQuery);


### PR DESCRIPTION
    Enable bulk placeholder creation directly from the
    Similar Dishes field in the Encyclopedia admin. Users
    can create multiple placeholders at once via a modal
    interface, with automatic linking to the current entry.

    Leverage modal pattern from other admin customizations
    to maintain consistency. Use batch creation with progress
    tracking to improve efficiency when adding multiple items.

    🤖 Generated with [Claude Code](https://claude.com/claude-code)

    Co-Authored-By: Claude <noreply@anthropic.com>